### PR TITLE
feat: support PHP 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A comprehensive immutable value objects implementation",
     "type": "library",
     "require": {
-        "php": "^8.3",
+        "php": "^8.2",
         "illuminate/collections": "^11.3",
         "ramsey/uuid": "^4.7",
         "illuminate/validation": "^11.3",

--- a/src/Bag/Casts/MagicCast.php
+++ b/src/Bag/Casts/MagicCast.php
@@ -36,7 +36,7 @@ class MagicCast implements CastsPropertySet
             is_subclass_of($propertyType, Bag::class, true) => $propertyType::from($value),
             is_subclass_of($propertyType, Collection::class, true) => $propertyType::make($value),
             is_subclass_of($propertyType, BackedEnum::class, true) => $propertyType::from($value),
-            is_subclass_of($propertyType, UnitEnum::class, true) => $propertyType::{$value},
+            is_subclass_of($propertyType, UnitEnum::class, true) => constant("{$propertyType}::{$value}"),
             default => $value,
         };
     }


### PR DESCRIPTION
It's not currently possible to use this library with PHP < 8.3. While upgrading to PHP 8.3 is the obvious desirable solution, it's not an immediately available or feasible option for many PHP developers.

It would be nice to be able to use this library through PHP 8.2's official end-of-life: active support [will continue](https://www.php.net/supported-versions.php) through 8 Dec 2024 (a bit over 6 months from the date of this writing) and security support for another year after that.

It appears that supporting PHP 8.2 is currently possible with one small change (included in this PR) to code that causes a syntax error under PHP < 8.3. It's worth noting that the affected line does not presently appear to have all branches or paths covered by tests. However, with the change, all existing tests pass under PHP 8.2. If I understand the function of the affected line correctly, [using `constant()`](https://stackoverflow.com/a/72901277) is an equivalent backward-compatible way of producing the same behavior.