### PR TITLE
feat: add support for Optionals

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -10,7 +10,7 @@ export default withMermaid(defineVersionedConfig({
   description: "Immutable Value Objects for PHP 8.3+",
   base: BASE_PATH,
   versioning: {
-    latestVersion: '2.4',
+    latestVersion: '2.5',
   },
   head: [
     [
@@ -91,6 +91,7 @@ export default withMermaid(defineVersionedConfig({
             {"text": "Variadics", "link": "/variadics"},
             {"text": "Hiding Properties", "link": "/hidden"},
             {"text": "Transformers", "link": "/transformers"},
+            {"text": "Optionals", "link": "/optionals"},
             {"text": "Validation", "link": "/validation"},
             {"text": "Computed Properties", "link": "/computed-properties"},
             {"text": "Output", "link": "/output"},
@@ -118,6 +119,50 @@ export default withMermaid(defineVersionedConfig({
         },
         {"text": "What's New", "link": "/whats-new"},
         {"text": "Upgrading to Bag 2", "link": "/upgrading"}
+      ],
+      "/2.4/": [
+          {
+            "text": "Get Started",
+            "items": [
+              {"text": "Installation", "link": "/2.4/install"},
+              {"text": "Basic Usage", "link": "/2.4/basic-usage"}
+            ]
+          },
+          {
+            "text": "Using Bag",
+            "items": [
+              {"text": "Collections", "link": "/2.4/collections"},
+              {"text": "Casting Values", "link": "/2.4/casting"},
+              {"text": "Mapping", "link": "/2.4/mapping"},
+              {"text": "Variadics", "link": "/2.4/variadics"},
+              {"text": "Hiding Properties", "link": "/2.4/hidden"},
+              {"text": "Transformers", "link": "/2.4/transformers"},
+              {"text": "Validation", "link": "/2.4/validation"},
+              {"text": "Computed Properties", "link": "/2.4/computed-properties"},
+              {"text": "Output", "link": "/2.4/output"},
+              {"text": "Wrapping", "link": "/2.4/wrapping"},
+              {"text": "Factories/2.3/ Testing", "link": "/2.4/testing"}
+            ]
+          },
+          {
+            "text": "Laravel Integration",
+            "items": [
+              {"text": "Controller Injection", "link": "/2.4/laravel-controller-injection"},
+              {"text": "Route Parameter Binding", "link": "/2.4/laravel-route-parameter-binding"},
+              {"text": "Eloquent Casting", "link": "/2.4/laravel-eloquent-casting"},
+              {"text": "Generating Bag Classes", "link": "/2.4/laravel-artisan-make-bag-command"},
+            ]
+          },
+          {
+            "text": "Other",
+            "items": [
+              {"text": "Creating Bags from Objects", "link": "/2.4/object-to-bag"},
+              {"text": "Why Bag?", "link": "/2.4/why"},
+              {"text": "How Bag Works", "link": "/2.4/how-bag-works"},
+            ]
+          },
+        {"text": "What's New", "link": "/2.4/whats-new"},
+        {"text": "Upgrading to Bag 2", "link": "/2.4/upgrading"}
       ],
       "/2.3/": [
           {

--- a/docs/optionals.md
+++ b/docs/optionals.md
@@ -1,0 +1,108 @@
+# Optionals
+
+Bag supports optional parameters using the `Optional` class. `Optional` parameters are parameters 
+that can be omitted when creating a Bag object, and will automatically be excluded from array and JSON 
+representations.
+
+[!NOTE]
+> Optional parameters are _different_ from nullable parameters, nulls are still included in the output, 
+> and can be combined with `Optional`. Optional parameters **will not** be filled with nulls when omitted. 
+
+[!WARN]
+> You _must_ specify at least one other type. Optionals cannot be combined with `mixed`.
+
+To make a property optional, use a union type that includes `Optional`:
+
+```php
+use Bag\Bag;
+
+class MyValue extends Bag
+{
+    public function __construct(
+        public string $name,
+        public Optional|int $age,
+        public Optional|string|null $email = null,
+    ) {}
+}
+```
+
+In the above example, the `age` property is optional, and can be omitted when creating a `MyValue` object:
+
+```php
+$value = new MyValue(name: 'Davey Shafik', email: null);
+
+$value->toArray(); // ['name' => 'Davey Shafik', 'email' => null]
+$value->toJson(); // {"name": "Davey Shafik", "email": null}
+```
+
+In the above example, the `age` property is omitted, and the `email` property is explicitly set to `null`. Omitting the `email` property would result in an `Optional` being used.
+
+## Value Presence
+
+Because optional properties are set to the `Optional` class, a simple `isset()` check will not work. Instead, you must use the `->has()`, `->hasAll()`, and `->hasAny()` methods instead:
+
+```php
+$value = new MyValue(name: 'Davey Shafik', email: null);
+
+$value->has('name'); // true
+$value->has('age'); // false
+$value->has('email'); // true
+
+$value->hasAny('age', 'email'); // true
+
+$value->hasAll('age', 'email'); // false
+```
+
+
+## Validation
+
+Because Optional properties have a value (an `Optional` object), validation may not work like expected. Bag provides
+a custom wrapper rule `\Bag\Validation\Rules\Optional` that can be used to validate optional properties correctly.
+
+The `Optional` rule will pass validation if the property is set to Optional, but will run the validation rules on the value if it is not:
+
+```php
+use Bag\Bag;
+use Bag\Validation\Rules\OptionalOr;
+
+class MyValue extends Bag
+{
+    public function __construct(
+        public string $name,
+        public Optional|int $age,
+        public Optional|string|null $email = null,
+    ) {}
+
+    public function rules(): array
+    {
+        return [
+            'age' => [new OptionalOr(['required', 'integer'])],
+            'email' => [new OptionalOr(['nullable', 'email'])],
+        ];
+    }
+}
+
+// All of the following are valid
+
+// both age and email are optional
+$value = new MyValue(name: 'Davey Shafik'); 
+// age is an int, email is optional
+$value = new MyValue(name: 'Davey Shafik', age: 40); 
+// age is optional, email is nullable
+$value = new MyValue(name: 'Davey Shafik', email: null) 
+// age is integer, email is an email
+$value = new MyValue(name: 'Davey Shafik', age: 40, email: 'davey@php.net') 
+
+// While these are invalid:
+
+// age is not an int, email is optional
+$value = new MyValue(name: 'Davey Shafik', age: '40'); 
+
+// age is required, email is optional
+$value = new MyValue(name: 'Davey Shafik', age: null); 
+
+// email is not an email, age is optional
+$value = new MyValue(name: 'Davey Shafik', email: 'foo'); 
+```
+
+The `OptionalOr` class accepts an array of rules, a single string rule, or a class name that the value should be an `instanceof`.

--- a/docs/versions/2.4/basic-usage.md
+++ b/docs/versions/2.4/basic-usage.md
@@ -1,0 +1,164 @@
+# Basic Usage
+
+## Creating a Value Object
+
+To create a new Value Object, extend the `Bag\Bag` class and define your properties in the constructor:
+
+```php
+use Bag\Bag;
+
+readonly class MyValue extends Bag {
+    public function __construct(
+        public string $name,
+        public int $age,
+    ) {
+    }
+}
+```
+
+> [!TIP]
+> You can add an `@method` annotation to your class to provide auto-complete for the `::from()` method, or use the [Artisan Command with the --doc option](laravel-artisan-make-bag-command.md#updating-documentation) to generate it for you.
+
+
+## Instantiating a Value Object
+
+To create a new instance of your Value Object, call the `::from()` method. You can use an array, a Collection, named arguments, or positional arguments.
+
+
+### Named Arguments
+
+```php
+$value = MyValue::from(
+    name: 'Davey Shafik',
+    age: => 40,
+);
+```
+
+### Array or Collection of Arguments
+
+```php
+$value = MyValue::from([
+    'name' => 'Davey Shafik',
+    'age' => 40,
+]);
+```
+
+or:
+
+```php
+$value = MyValue::from(collect([
+    'name' => 'Davey Shafik',
+    'age' => 40,
+]));
+```
+
+### Positional Arguments
+
+```php
+$value = MyValue::from('Davey Shafik', 40);
+```
+
+> [!WARNING]
+> If you use positional arguments, you must ensure they are in the same order as the constructor.
+
+> [!WARNING]
+> If you have a single array argument, **and** an array [transformer](./transformers), the transformer will be applied to the array, potentially causing unwanted side-effects.
+
+## Type Casting
+
+If the input value matches the type of the property (including [union types](https://www.php.net/manual/en/language.types.type-system.php#language.types.type-system.composite.union)), it will be used as-is. Otherwise, Bag will cast all values to their defined type _automatically_ for all scalar types, as well as the following:
+
+- `Bag` objects
+- `\Bag\Collection` and `\Illuminate\Support\Collection` objects
+- `\DateTimeInterface` objects will be cast using standard [PHP Date/Time formats](https://www.php.net/manual/en/datetime.formats.php)
+    - This includes `\DateTime`, `\DateTimeImmutable`, `\Carbon\Carbon` and `\Carbon\CarbonImmutable`
+- Enums
+
+> [!TIP]
+> We recommend using `\Carbon\CarbonImmutable` for all date times.
+
+## Default Values
+
+You can define default values for your properties by setting them in the constructor:
+
+```php
+use Bag\Bag;
+
+readonly class MyValue extends Bag {
+    public function __construct(
+        public string $name,
+        public int $age = 40,
+    ) {
+    }
+}
+
+$value = MyValue::from([
+    'name' => 'Davey Shafik',
+])->toArray(); // ['name' => 'Davey Shafik', 'age' => 40]
+```
+
+## Nullable Values
+
+Bag will fill missing nullable values without a default value with `null`:
+
+```php
+use Bag\Bag;
+
+readonly class MyValue extends Bag {
+    public function __construct(
+        public string $name,
+        public ?int $age,
+    ) {
+    }
+}
+
+$value = MyValue::from([
+    'name' => 'Davey Shafik',
+])->toArray(); // ['name' => 'Davey Shafik', 'age' => null]
+```
+
+## Stripping Extra Parameters
+
+By default, Bag will throw a `\Bag\Exceptions\AdditionalPropertiesException` exception if you try to instantiate a non-variadic Bag with extra parameters. You can disable this behavior by adding the `StripExtraParameters` attribute to the class:
+
+```php
+use Bag\Attributes\StripExtraParameters;
+use Bag\Bag;
+
+#[StripExtraParameters]
+readonly class MyValue extends Bag {
+    public function __construct(
+        public string $name,
+        public ?int $age,
+    ) {
+    }
+}
+
+$value = MyValue::from([
+    'name' => 'Davey Shafik',
+    'test' => true,
+])->toArray(); // [ 'name' => 'Davey Shafik', 'age' => null ] (note that 'test' is stripped)
+```
+
+> [!TIP]
+> You can also use the `StripExtraParameters` attribute when [injecting a Bag object into a controller](./laravel-controller-injection.md#avoiding-extra-parameters).
+
+### Modifying a Value Object
+
+Value Objects are immutable, so you cannot change their properties directly. Instead, you can create a new instance with the updated values using the `Bag->with()` or `Bag->append()` methods:
+
+```php
+$value = MyValue::from([
+    'name' => 'Davey Shafik',
+    'age' => 40,
+]);
+
+$newValue = $value->with(age: 41);
+
+dump($newValue->toArray()); // ['name' => 'Davey Shafik', 'age' => 41] 
+```
+
+You can pass either named arguments, or an array or Collection of key-value pairs to the `Bag->with()` method. 
+
+> [!TIP]
+> The `Bag->append()` method works the same way as `Bag->with()`, but it will not validate the new value object. You can manually validate the object using `Bag->valid()`.

--- a/docs/versions/2.4/casters.md
+++ b/docs/versions/2.4/casters.md
@@ -1,0 +1,134 @@
+# Built-in Casters
+
+The following built-in explicit casters are available:
+
+## Bag Collections
+
+`\Bag\Casts\CollectionOf` casts an array to a [Collection](./collections) of Bag objects.
+
+```php
+use Bag\Bag;
+use Bag\Attributes\Cast;
+use Bag\Casts\CollectionOf;
+use Bag\Collection;
+
+class MyValue extends Bag {
+    public function __construct(
+        #[Cast(CollectionOf::class, MyOtherValue::class)]    
+        public Collection $values,
+    ) {
+    }
+}
+
+$value = MyValue::from([
+    'values' => [
+        ['name' => 'Davey Shafik', 'age' => 40],
+        …
+    ],
+]);
+
+dump($value->values); // Collection<MyOtherValue>
+```
+
+> [!TIP]
+> The `CollectionOf` caster will use the appropriate Collection class based on the Bag class provided.
+
+## Dates & Time
+
+`\Bag\Casts\DateTime` casts a date/time string to an object that implements the `\DateTimeInterface` interface.
+
+```php
+use Bag\Bag;
+use Bag\Attributes\Cast;
+use Bag\Casts\DateTime;
+use Carbon\CarbonImmutable;
+
+class MyValue extends Bag {
+    public function __construct(
+        #[Cast(
+            DateTime::class, 
+            format: 'u', 
+            outputFormat: 
+            'Y-m-d', strictMode: true
+        )]
+        public CarbonImmutable $dateOfBirth,
+    ) {
+    }
+}
+
+$value = MyValue::from([
+    // Requires a UNIX timestamp input due to strictMode: true
+    'dateOfBirth' => '454809600', 
+]);
+
+$value->dateOfBirth; // CarbonImmutable{date: 1984-05-31 00:00:00 UTC}
+$value->toArray(); // ['dateOfBirth' => '1984-05-31'] due to outputFormat
+```
+
+The `DateTime` cast accepts the following parameters:
+
+- `format` - The format of the input and output date/time string (see [PHP date/time format](https://www.php.net/manual/en/datetimeimmutable.createfromformat.php#datetimeimmutable.createfromformat.parameters))
+- `outputFormat` - The format of the output date/time string, this will override the `format` parameter for output only
+- `strictMode` - If `true`, the input date/time string must match the `format` parameter exactly, otherwise it is parsed as best as possible
+- `dateTimeClass` - The class to use for the date/time object, must implement `\DateTimeInterface`, this must be compatible with the property type hint, and defaults to the type hint value
+
+> [!TIP]
+> We recommend using `CarbonImmutable` as type for all date/time casting.
+
+## Money
+
+`\Bag\Casts\MoneyFromMinor` Casts a number to a `\Brick\Money\Money` object assuming minor units (e.g. Cents)
+
+```php
+use Bag\Bag;
+use Bag\Attributes\Cast;
+use Bag\Casts\MoneyFromMinor;
+use Brick\Money\Money;
+
+class MyValue extends Bag {
+    public function __construct(
+        #[Cast(MoneyFromMinor::class, currency: 'USD')]
+        public Money $amount,
+    ) {
+    }
+}
+
+$value = MyValue::from([
+    'amount' => 1000,
+]);
+
+dump($value->amount); // Money object with a value of 10.00 USD
+```
+
+`\Bag\Casts\MoneyFromMajor` Casts a number to a `\Brick\Money\Money` object assuming major units (e.g. Dollars)
+
+```php
+use Bag\Bag;
+use Bag\Attributes\Cast;
+use Bag\Casts\MoneyFromMajor;
+use Brick\Money\Money;
+
+class MyValue extends Bag {
+    public function __construct(
+        #[Cast(MoneyFromMajor::class, currency: 'USD')]
+        public Money $amount,
+    ) {
+    }
+}
+
+$value = MyValue::from([
+    'amount' => 1000,
+]);
+
+dump($value->amount); // Money object with a value of 1,000.00 USD
+```
+
+Both `MoneyFromMajor` and `MoneyFromMinor` accept the following parameters:
+
+- `currency` - The currency code to use for the `\Brick\Money\Money` object, either a 3-letter ISO 4217 code or a [`\PrinsFrank\Standards\Currency\CurrencyAlpha3`](https://github.com/PrinsFrank/standards/blob/main/src/Currency/CurrencyAlpha3.php#L22) enum case.
+- `currencyProperty` - The input parameter to use for the currency code
+- `locale` - The locale to use for formatting the money object, defaults to `en_US`
+
+> [!TIP]
+> Best practices recommend that you always handle money as strings of minor units, _however_ if you are working with user input it's most likely in major units.
+> We recommend using `MoneyFromMajor` as the input caster and `MoneyFromMinor` as the output caster for handling user input.

--- a/docs/versions/2.4/casting.md
+++ b/docs/versions/2.4/casting.md
@@ -1,0 +1,107 @@
+# Casting Values
+
+Casting allows you to format input and output values appropriately. 
+
+## Explicit Casting
+
+You can explicitly cast input and/or output values to a specific type using annotations. This allows you to cast simple values to complex values,
+or simply transform it in some way. For example, you can cast a number to a `\Brick\Money\Money` object or a timestamp to a `\Carbon\CarbonImmutable` object.  
+
+Casts can act on both input and output, depending on if they implement `CastsPropertySet` or `CastsPropertyGet`.
+
+Output casts are applied when calling `toArray()`, `toCollection()`, or when serializing to JSON.
+
+The following annotations are available:
+
+- `Bag\Attributes\Cast` - Cast both input and output depending on whether it implements `CastsPropertySet` and/or `CastsPropertyGet`
+- `Bag\Attributes\CastInput` — Only cast input (requires the caster implements `CastsPropertySet`)
+- `Bag\Attributes\CastOutput` — Only cast output (requires the caster implements `CastsPropertyGet`)
+
+```php
+use Bag\Bag;
+use Bag\Attributes\Cast;
+use Bag\Casts\DateTime;
+use Carbon\CarbonImmutable;
+
+readonly class MyValue extends Bag {
+    public function __construct(
+        public string $name,
+        public int $age,
+        #[Cast(DateTime::class, format: 'Y-m-d')]
+        public CarbonImmutable $dateOfBirth,
+    ) {
+    }
+}
+```
+
+This will cast the `dateOfBirth` property to a `\Carbon\CarbonImmutable` object using the `Y-m-d` format:
+
+```php
+$value = MyValue::from([
+    'name' => 'Davey Shafik',
+    'age' => 40,
+    'dateOfBirth' => '1984-05-31',
+]);
+```
+
+When you access the `dateOfBirth` property directly, it will be a `\Carbon\CarbonImmutable` object:
+
+```php
+dump($value->dateOfBirth); // CarbonImmutable
+```
+
+However, if you call `toArray()` or `toCollection()` then it will be formatted using the format you specified:
+
+```php
+dump($value->toArray()); // ['name' => 'Davey Shafik', 'age' => 40, 'dateOfBirth' => '1984-05-31']
+```
+
+### Available Casts
+
+Bag supports several [built-in casters](./casters), and you can create your own by implementing `CastsPropertySet` and/or `CastsPropertyGet`.
+
+
+## Automatic Casting
+
+If no cast attribute is provided, input values are _automatically_ cast to the correct type based on the type hint of the property when possible.
+
+The following types are automatically cast:
+
+- Scalar types (i.e. `int`, `float`, `bool`, `string`)
+- `\CarbonImmutable`, `\Carbon`, `\DateTimeImmutable`, and `\DateTime` objects (parsing the value using [PHP date/time formats](https://www.php.net/manual/en/datetime.formats.php))
+- `Bag` objects from arrays
+- Laravel Collections (i.e. `collect($value)`)
+- BackedEnums from value (i.e. `public FooEnum $foo` will cast the value `BAR` using `FooEnum::from('BAR')`)
+- UnitEnums by name (i.e. `public FooEnum $foo` will cast the value `BAR` to `FooEnum::BAR`)
+- Laravel Models from IDs (using `Model::findOrFail($value)`)
+
+All other types will be set to the input value (which may be invalid). Input objects that match the type hint are not re-cast.
+
+For example, given the following Bag class:
+
+```php
+use Bag\Bag;
+use Carbon\CarbonImmutable;
+
+class MyValue extends Bag {
+    public function __construct(
+        public CarbonImmutable $dateOfBirth,
+    ) {
+    }
+}
+```
+
+When you create a new instance of `MyValue`, the `dateOfBirth` property will be a `\Carbon\CarbonImmutable` object:
+
+```php
+MyValue::from([
+    'dateOfBirth' => '1984-05-31',
+]);
+```
+
+However, if you pass in a value like `12:34:56`, it will result in a `\Carbon\CarbonImmutable` object with the current date and the time set to `12:34:56`.
+
+> [!WARNING]
+> To avoid this issue, we recommend always using a `DateTime` cast as shown above, setting the `strictMode` parameter to `true`. This allows you to specify a required input format.
+
+When you access the `dateOfBirth` property directly, it will be the `\Carbon\CarbonImmutable` object.

--- a/docs/versions/2.4/collections.md
+++ b/docs/versions/2.4/collections.md
@@ -1,0 +1,73 @@
+# Collections
+
+## Using Collections
+
+You can create a collection of Value objects using the `Bag::collect()` method:
+
+```php
+$values = MyValue::collect([
+    [
+        'name' => 'Davey Shafik',
+        'age' => 40,
+    ],
+    [
+        'name' => 'Taylor Otwell',
+        'age' => 40,
+    ],
+]);
+```
+
+This will create a `\Bag\Collection` of `MyValue` objects.
+
+### Extending Laravel Collections
+
+`Bag\Collection` extends `\Illuminate\Support\Collection` and has [most of the same methods](https://laravel.com/docs/12.x/collections#available-methods).
+
+The following methods will throw an exception if used:
+
+- `->pull()`
+- `->shift()`
+- `->splice()`
+- `->transform()`
+- `->getOrPut()`
+- `offsetSet()` (used with array access)
+- `offsetUnset()` (used with array access)
+- `__set()` (used when setting arbitrary properties)
+
+In addition, the following will create a new `Bag\Collection` instance instead of modifying the original:
+
+- `->forget()`
+- `->pop()`
+- `->prepend()`
+- `->push()`
+- `->put()`
+
+## Custom Collections
+
+If you want to use a custom collection class, you must first create a new class that extends `\Bag\Collection`:
+
+```php
+use Bag\Collection;
+
+class MyValueCollection extends Collection {
+}
+```
+
+Then you can use this collection class in your Value object by adding the `Collection` attribute to your Bag class:
+
+```php
+use App\Values\Collections\MyValueCollection;
+use Bag\Bag;
+use Bag\Attributes\Collection;
+
+#[Collection(MyValueCollection::class)
+readonly class MyValue extends Bag {
+    public function __construct(
+        public string $name,
+        public int $age,
+    ) {
+    }
+}
+```
+
+When using `MyValue::collect()` a `MyValueCollection` object will be returned.

--- a/docs/versions/2.4/computed-properties.md
+++ b/docs/versions/2.4/computed-properties.md
@@ -1,0 +1,28 @@
+# Computed Properties
+
+Bag supports computed properties, these are properties that are derived at creation time rather than passed in.
+
+Failing to set a computed property will result in a `Bag\Exceptions\ComputedPropertyMissing` exception.
+
+## Using Computed Properties
+
+To use computed properties, define the property in your class, and add the `Bag\Attributes\Computed` attributed:
+
+```php{7,11}
+use Bag\Bag;
+use Bag\Attributes\Computed;
+use Carbon\CarbonImmutable;
+
+class MyValue extends Bag
+{
+    #[Computed]
+    public string $computedProperty;
+    
+    public function __construct() {
+        $this->computedProperty = CarbonImmutable::now();
+    }
+}
+```
+
+> [!WARNING]
+> You **must** set the property within the constructor, otherwise an exception will be thrown.

--- a/docs/versions/2.4/hidden.md
+++ b/docs/versions/2.4/hidden.md
@@ -1,0 +1,79 @@
+# Hidden Properties
+
+Bag supports hiding properties when transforming to an array and/or JSON. 
+This is useful when you want to keep certain properties private, or when you want to hide sensitive information.
+
+Hidden properties are still accessible as object properties (e.g. `$bag->hiddenProperty`), but they will not be included
+in the output when transforming to an array and/or JSON.
+
+## Hiding Properties
+
+Properties can be hidden by applying the `Hidden` attribute to the property:
+
+```php
+use Bag\Attributes\Hidden;
+use Bag\Bag;
+
+class MyValue extends Bag {
+    public function __construct(
+        #[Hidden]
+        public string $hiddenProperty
+        public string $visibleProperty
+    ) {}
+}
+```
+
+In the above example, the `hiddenProperty` will not be included when calling `toArray()`, `toCollection()` or `json_encode()`:
+
+```php
+$value = MyValue::from([
+    'hiddenProperty' => 'hidden',
+    'visibleProperty' => 'visible'
+]);
+
+$value->toArray(); // ['visibleProperty' => 'visible']
+json_encode($value, JSON_THROW_ON_ERROR); // {"visibleProperty": "visible"}
+```
+
+Additionally, you can use PHP's built-in `SensitiveParameter` attribute to hide sensitive information:
+
+```php
+use Bag\Bag;
+use SensitiveParameter;
+
+class MyValue extends Bag {
+    public function __construct(
+        #[SensitiveParameter]
+        public string $password
+    ) {}
+}
+```
+
+## Hiding Properties from JSON
+
+In addition to always hiding properties, you can choose to _only_ hide them when serializing to JSON by using the `HiddenFromJson` attribute:
+
+```php
+use Bag\Attributes\HiddenFromJson;
+use Bag\Bag;
+
+class MyValue extends Bag {
+    public function __construct(
+        #[HiddenFromJson]
+        public string $hiddenProperty
+        public string $visibleProperty
+    ) {}
+}
+```
+
+In the above example, the `hiddenProperty` will be included when calling `json_encode()`, but not when calling `toArray()`:
+
+```php
+$value = MyValue::from([
+    'hiddenProperty' => 'hidden',
+    'visibleProperty' => 'visible'
+]);
+
+$value->toArray(); // ['hiddenProperty' => 'hidden', visibleProperty' => 'visible']
+json_encode($value, JSON_THROW_ON_ERROR); // {"visibleProperty": "visible"}
+```

--- a/docs/versions/2.4/how-bag-works.md
+++ b/docs/versions/2.4/how-bag-works.md
@@ -1,0 +1,221 @@
+# How Bag Works
+
+Bag works by utilizing pipelines to process the input and output data. 
+
+There are four pipelines:
+
+- `InputPipeline` for handling input and constructing the Bag object 
+- `ValidationPipeline` for validating without constructing the Bag object
+- `OutputPipeline` for handling output
+- `OutputCollectionPipeline` for handling collection output
+
+Each pipeline is detailed below.
+
+> [!TIP]
+> Each stage in the diagrams below is linked to the relevant source code for that stage.
+
+## The Input Pipeline
+
+The [`InputPipeline`](https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/InputPipeline.php) is responsible for processing the input data so that the `Bag` object can be created. The pipeline
+consists of the following steps:
+
+```mermaid
+graph TD;
+start("Bag::from($data)")
+--> transform(Transform Input)
+--> process(Process Parameters) 
+--> variadic(Is Variadic?)
+--> fillNulls(Fill Nulls)
+--> mapInput(Map Input)
+--> laravelParams(Laravel Route Parameter Binding)
+-- Finalized Input Values --> missing(Missing Parameters) --> missingError{Error?}
+missingError -- Yes --> errorMissingParameters(MissingPropertiesException)
+missingError -- No --> extra(Extra Parameters) --> extraError{Error?}
+extraError -- Yes --> errorExtraParameters(AdditionalPropertiesException)
+extraError -- No --> strip(Strip Extra Parameters)
+--> validate(Validate)
+--> valid{Valid?}
+valid -- No --> errorValidation(ValidationException)
+valid -- Yes --> cast(Cast Input)
+--> construct("new Bag(...)")
+--> computed(Verify Computed Values)
+--> initialized{Initialized?}
+initialized -- No --> errorInitialization(ComputedPropertyUninitializedException)
+initialized -- Yes
+--> bag(Bag Value Returned)
+
+class start mermaid-start
+class missingError,extraError,valid,initialized mermaid-decision
+class bag mermaid-end
+class errorMissingParameters,errorExtraParameters,errorValidation,errorInitialization mermaid-error
+
+click start "https://github.com/dshafik/bag/blob/main/src/Bag/Bag.php" _blank
+click transform "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/Transform.php" _blank
+click process "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/ProcessParameters.php" _blank
+click variadic "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/IsVariadic.php" _blank
+click fillNull "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/FillNulls.php" _blank
+click mapInput "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/MapInput.php" _blank
+click laravelParams "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/LaravelRouteParameters.php" _blank
+click missing "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/MissingParameters.php" _blank
+click extra "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/ExtraParameters.php" _blank
+click strip "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/StripExtraParameters.php" _blank
+click validate "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/Validate.php" _blank
+click cast "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/CastInputValues.php" _blank
+click construct "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/FillBag.php" _blank
+click computed "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/ComputedValues.php" _blank
+```
+
+## The Output Pipeline
+
+The `OutputPipeline` is responsible transforming the Bag data to the desired output array or JSON. The pipeline consists of the following steps:
+
+```mermaid
+graph TD;
+toArray("Bag->toArray()") --> processParameters
+toCollection("Bag->toCollection()") --> processParameters
+toJson("Bag->toJson()") --> processParameters
+jsonEncode("json_encode($bag)") --> processParameters
+get("Bag->get()") --> processParameters
+unwrapped("Bag->unwrapped()") --> processParameters
+processParameters(Process Parameters)
+--> processProperties(Process Properties)
+--> getValues(Get Values)
+--> hide("Remove Hidden Attributes*")
+--> hideJson("Remove Hidden JSON Attributes*")
+--> cast(Cast Output)
+--> mapOutput(Map Output)
+--> wrap(Wrap Output*)
+--> output(array or JSON string)
+
+class toArray,toCollection,toJson,jsonEncode,get,unwrapped mermaid-start
+class output mermaid-end
+class hide,hideJson,wrap mermaid-conditional
+
+click toArray "https://github.com/dshafik/bag/blob/main/src/Bag/Concerns/WithArrayable.php" _blank
+click toCollection "https://github.com/dshafik/bag/blob/main/src/Bag/Concerns/WithCollections.php" _blank
+click toJson "https://github.com/dshafik/bag/blob/main/src/Bag/Concerns/WithJson.php" _blank
+click get "https://github.com/dshafik/bag/blob/main/src/Bag/Concerns/WithOutput.php" _blank
+click unwrapped "https://github.com/dshafik/bag/blob/main/src/Bag/Concerns/WithOutput.php" _blank
+click processParameters "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/ProcessParameters.php" _blank
+click processProperties "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/ProcessProperties.php" _blank
+click getValues "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/GetValues.php" _blank
+click hide "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/HideValues.php" _blank
+click hideJson "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/HideJsonValues.php" _blank
+click cast "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/CastOutputValues.php" _blank
+click mapOutput "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/MapOutput.php" _blank
+click wrap "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/Wrap.php" _blank
+```
+
+> [!NOTE]
+> \* These steps are only performed if the Bag is being converted to an array and/or JSON.
+
+## The Validation Pipeline
+
+The `ValidationPipeline` is responsible for validating the input data without constructing the Bag object. The pipeline consists of the following steps:
+
+```mermaid
+graph TD;
+start("Bag::validate($data)")
+--> transform(Transform Input)
+--> process(Process Parameters) 
+--> variadic(Is Variadic?)
+--> fillNulls(Fill Nulls)
+--> mapInput(Map Input)
+-- Finalized Input Values --> missing(Missing Parameters) --> missingError{Error?}
+missingError -- Yes --> errorMissingParameters(MissingPropertiesException)
+missingError -- No --> extra(Extra Parameters) --> extraError{Error?}
+extraError -- Yes --> errorExtraParameters(AdditionalPropertiesException)
+extraError -- No --> strip(Strip Extra Parameters) 
+--> validate(Validate)
+--> valid{Valid?}
+valid -- No --> errorValidation(ValidationException)
+valid -- Yes --> success(return true)
+
+class start mermaid-start
+class missingError,extraError,valid mermaid-decision
+class success mermaid-end
+class errorMissingParameters,errorExtraParameters,errorValidation mermaid-error
+
+click start "https://github.com/dshafik/bag/blob/main/src/Bag/Concerns/WithValidation.php" _blank
+click transform "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/Transform.php" _blank
+click process "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/ProcessParameters.php" _blank
+click variadic "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/IsVariadic.php" _blank
+click fillNulls "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/FillNulls.php" _blank
+click mapInput "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/MapInput.php" _blank
+click missing "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/MissingParameters.php" _blank
+click extra "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/ExtraParameters.php" _blank
+click strip "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/StripExtraParameters.php" _blank
+click validate "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/Validate.php" _blank
+```
+
+## The Without Validate Pipeline
+
+The [`WithoutValidationPipeline`](https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/WithoutValidationPipeline.php) is identical to the `InputPipeline` but does not perform validation. The pipeline
+consists of the following steps:
+
+```mermaid
+graph TD;
+start("Bag::from($data)")
+--> transform(Transform Input)
+--> process(Process Parameters) 
+--> variadic(Is Variadic?)
+--> fillNulls(Fill Nulls)
+--> mapInput(Map Input)
+--> laravelParams(Laravel Route Parameter Binding)
+-- Finalized Input Values --> missing(Missing Parameters) --> missingError{Error?}
+missingError -- Yes --> errorMissingParameters(MissingPropertiesException)
+missingError -- No --> strip(Strip Extra Parameters)
+--> construct("new Bag(...)")
+--> computed(Verify Computed Values)
+--> initialized{Initialized?}
+initialized -- No --> errorInitialization(ComputedPropertyUninitializedException)
+initialized -- Yes
+--> bag(Bag Value Returned)
+
+class start mermaid-start
+class missingError,extraError,valid,initialized mermaid-decision
+class bag mermaid-end
+class errorMissingParameters,errorExtraParameters,errorValidation,errorInitialization mermaid-error
+
+click start "https://github.com/dshafik/bag/blob/main/src/Bag/Bag.php" _blank
+click transform "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/Transform.php" _blank
+click process "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/ProcessParameters.php" _blank
+click variadic "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/IsVariadic.php" _blank
+click fillNulls "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/FillNulls.php" _blank
+click mapInput "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/MapInput.php" _blank
+click laravelParams "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/LaravelRouteParameters.php" _blank
+click missing "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/MissingParameters.php" _blank
+click strip "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/StripExtraParameters.php" _
+click validate "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/Validate.php" _blank
+click cast "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/CastInputValues.php" _blank
+click construct "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/FillBag.php" _blank
+click computed "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/ComputedValues.php" _blank
+```
+
+## The Output Collection Pipeline
+
+The `OutputCollectionPipeline` is responsible for transforming the Bag collection data to the desired output array or JSON. The pipeline consists of the following steps:
+
+```mermaid
+graph TD;
+toArray("Collection->toArray()") --> wrap
+toJson("Collection->toJson()") --> wrap
+jsonEncode("json_encode($collection)") --> wrap
+unwrapped("Collection->unwrapped()") --> wrap
+wrap(Wrap Collection*)
+--> output(array or JSON string)
+
+class toArray,toJson,jsonEncode,unwrapped mermaid-start
+class output mermaid-end
+
+click toArray "https://github.com/dshafik/bag/blob/main/src/Bag/Collection.php" _blank
+click toJson "https://github.com/dshafik/bag/blob/main/src/Bag/Collection.php" _blank
+click jsonEncode "https://github.com/dshafik/bag/blob/main/src/Bag/Collection.php" _blank
+click unwrapped "https://github.com/dshafik/bag/blob/main/src/Bag/Collection.php" _blank
+click wrap "https://github.com/dshafik/bag/blob/main/src/Bag/Pipelines/Pipes/WrapCollection.php" _blank
+```
+
+> [!NOTE]
+> \* This step is only performed if the Bag is being converted to an array and/or JSON.
+
+

--- a/docs/versions/2.4/index.md
+++ b/docs/versions/2.4/index.md
@@ -1,0 +1,41 @@
+---
+# https://vitepress.dev/reference/default-theme-home-page
+layout: home
+
+hero:
+  name: "Bag"
+  text: "Immutable Value Objects for PHP"
+  tagline: "<code>composer require dshafik/bag</code>"
+  image: /assets/images/bag.png
+  actions:
+    - theme: brand
+      text: Get Started
+      link: ./install
+
+features:
+  - title: Immutable & Strongly typed
+    icon: 🦾
+    details: Bag value objects are immutable and strongly typed, a safer and more predictable way to work with data.
+  - title: Composable
+    icon: 🛠
+    details: Nest Bag value objects and collections to create complex data structures.
+  - title: Built on Laravel
+    icon: 📦
+    details: Built-in validation, controller dependency injection, and more. Bag is designed to work seamlessly with Laravel.  
+---
+
+## What is Bag?
+
+Bag helps you create immutable value objects. It's a great way to encapsulate data within your application.
+
+Bag prioritizes immutability and type safety with built-in validation and data casting.
+
+### When should I use Value Objects?
+
+Value objects should be used in place of regular arrays, allowing you enforce type safety and immutability.
+
+### Does it work with Laravel/Symfony/Other Framework?
+
+Bag is framework-agnostic, but it works great with Laravel. Bag uses standard Laravel [Collections](https://laravel.com/docs/12.x/collections) and [Validation](https://laravel.com/docs/12.x/validation). 
+In addition, it will automatically inject `Bag\Bag` value objects into your controllers with validation.
+

--- a/docs/versions/2.4/install.md
+++ b/docs/versions/2.4/install.md
@@ -1,0 +1,15 @@
+# Get Started with Bag Value Objects
+
+Bag is a library for creating immutable value objects in PHP. It's a great way to encapsulate data within your application.
+
+## Requirements
+
+Bag requires PHP 8.2+, and supports Laravel 10+.
+
+## Installation
+
+To install Bag, use [Composer](https://getcomposer.org):
+
+```bash
+composer require dshafik/bag
+```

--- a/docs/versions/2.4/laravel-artisan-make-bag-command.md
+++ b/docs/versions/2.4/laravel-artisan-make-bag-command.md
@@ -1,0 +1,289 @@
+# Generate Bag Value Objects, Collections, and Factories
+
+Bag includes the `make:bag` artisan command to make it easy to generate new Bag classes, Factories, and Collections.
+
+> [!NOTE] Namespaces
+> The `make:bag` command will use the provided namespace to determine the location of the generated classes.
+> You can set the namespace using the `--namespace` option or you will be prompted for it. The default namespace is `\App\Values`.
+
+## Generating Bags
+
+To create a new Bag class, use the `make:bag` command:
+
+```bash
+php artisan make:bag MyBag
+```
+
+This will create a new `MyBag` class in `app/Values/MyBag.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Values;
+
+use Bag\Bag;
+
+readonly class MyBag extends Bag
+{
+    public function __construct() {
+    }
+}
+```
+
+## Generating Bag Collections
+
+To create a new Bag Collection class, use the `make:bag` command with the `--collection` option:
+
+```bash
+php artisan make:bag MyBag --collection
+```
+
+You can optionally specify the name of the collection class:
+
+```bash
+php artisan make:bag MyBag --collection=MyBagCollection
+```
+
+If none is specified, it will use prompt you for the collection name, and defaults to the Bag class name with `Collection` appended to it.
+
+This will create a new `MyBagCollection` class in `app/Values/Collections/MyBagCollection.php`.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Values\Collections;
+
+use Bag\Collection;
+
+class MyBagCollection extends Collection
+{
+}
+```
+
+> [!NOTE]
+> When creating a new Bag _or_ when specifying the `--update` flag, it will automatically add the `Collection` attribute to the Bag class if necessary.
+
+## Generating Bag Factories
+
+The `make:bag` command can also generate Bag Factory classes, **and** will _automatically_ generate the `definition()` function based on the Bag class properties.
+
+To create a new Bag Factory class, use the `make:bag` command with the `--factory` option:
+
+```bash
+php artisan make:bag MyBag --factory
+```
+
+This will create a new `MyBagFactory` class in `app/Values/Factories/MyBagFactory.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Values\Factories;
+
+use Bag\Factory;
+
+class TestFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+        ];
+    }
+}
+```
+
+> [!TIP]
+> When creating a new Bag _or_ when specifying the `--update` flag, it will automatically add the `Factory` attribute and `HasFactory` trait to the Bag class.
+
+## Updating Factories
+
+Once you had added properties to your Bag class, you can update the Factory class using the `--update` option:
+
+```bash
+php artisan make:bag MyBag --factory --docs --update
+```
+
+> [!TIP]
+> If you update the Bag class properties, you can re-run the `make:bag` command with the `--update` and `--force-excluding-bag` options to update the Factory class.
+
+For example, if we update our `MyBag` constructor to look like the following:
+
+```php
+public function __construct(
+    public string $name,
+    public int $age,
+    #[Cast(DateTime::class, 'y-m-d')]
+    public CarbonImmutable $birthday,
+    public Money $money,
+    public AnotherBag $test,
+    #[Cast(CollectionOf::class, AnotherBag::class)]
+    public Collection $collection,
+) {
+}
+```
+
+The generated factory will look like this:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Values\Factories;
+
+use App\Values\AnotherBag;
+use Bag\Factory;
+use Brick\Money\Money;
+use Carbon\CarbonImmutable;
+
+class MyBagFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->word(),
+            'age' => $this->faker->randomNumber(),
+            'birthday' => new CarbonImmutable(),
+            'money' => Money::ofMinor($this->faker->numberBetween(100, 10000), 'USD'),
+            'test' => AnotherBag::factory()->make(),
+            'collection' => AnotherBag::collect([AnotherBag::factory()->make()]),
+        ];
+    }
+}
+```
+
+## Documentation/Auto-Complete Helpers
+
+To enable easier use of named/positional arguments when creating a new Bag, you can use the `--docs` option to automatically generate it for the Bag,
+this will add an `@method` annotation to the Bag class to provide auto-complete for the `::from()` method:
+
+```bash
+php artisan make:bag MyBag --docs
+```
+
+This will add the following to the `MyBag` class:
+
+```php
+/**
+ * @method static static from(array $data)
+ */
+```
+
+## Updating Documentation
+
+Similar to Factories, you can update the documentation using the `--update` option:
+
+```bash
+php artisan make:bag MyBag --docs --update
+```
+
+This will update the `@method` annotation to include documentation for all defined Value attributes. For example, given the following bag:
+
+```php
+use App\Values\Collections\ReportCollection;
+use App\Values\Report;
+use App\Values\Team;
+use Carbon\CarbonImmutable;
+
+readonly class User extends Bag {
+    public function __construct(
+        public string $name,
+        public int $age,
+        public Team $team,
+        #[Cast(CollectionOf::class, Report::class)]
+        public ReportCollection $reports,
+        public CarbonImmutable $lastLogin,
+    ) {
+    }
+}
+```
+
+The `@method` annotation will added to the `User` class:
+
+```php
+use App\Values\Collections\ReportCollection;
+use App\Values\Report;
+use App\Values\Team;
+use Carbon\CarbonImmutable;
+
+/**
+ * @method static static from(string $name, int $age, Team $team, ReportCollection<Report> $reports, CarbonImmutable $lastLogin)
+ */
+readonly class User extends Bag {
+    public function __construct(
+        public string $name,
+        public int $age,
+        public Team $team,
+        #[Cast(CollectionOf::class, Report::class)]
+        public ReportCollection $reports,
+        public CarbonImmutable $lastLogin,
+    ) {
+    }
+}
+```
+
+## Expected Usage
+
+Because the factory is based on the Bag class properties, you will typically create and customize the Bag value object, and **then** create
+the factory and add docs. To do this, you would follow these steps:
+
+1. Create the Bag class (optionally, with a collection):
+
+```bash
+php artisan make:bag MyBag --collection
+```
+
+2. Customize the Bag class
+
+3. Create the Bag Factory and docs:
+
+```bash
+php artisan make:bag MyBag --factory --docs --update
+```
+
+If you have already created the factory, you must add the `--force-except-bag` option to overwrite it:
+
+```bash
+php artisan make:bag MyBag --factory --docs --update --force-except-bag
+```
+
+> [!WARNING]
+> If you use the `--force` option instead of `--force-except-bag` it will overwrite your customized Bag Value class, losing any customizations.
+
+## The `make:bag` Command
+
+The `make:bag` command has the following options:
+
+```
+Description:
+  Create a new Bag value class, with optional factory and collection.
+
+Usage:
+  make:bag [options] [--] <name>
+
+Arguments:
+  name                           
+
+Options:
+  -F, --force                    Force overwriting all files
+  -E, --force-except-bag         Force overwriting Factory/Collection files
+  -u, --update                   Update Bag class to add factory/collection
+  -f, --factory[=FACTORY]        Create a Factory for the Bag [default: "interactive"]
+  -c, --collection[=COLLECTION]  Create a Collection for the Bag [default: "interactive"]
+  -d, --docs                     Add Bag::from() docs to the Bag for IDE auto-complete
+  -N, --namespace[=NAMESPACE]    Specify the namespace for the Bag
+      --pretend                  Dump the file contents instead of writing to disk
+  -h, --help                     Display help for the given command. When no command is given display help for the list command
+  -q, --quiet                    Do not output any message
+  -V, --version                  Display this application version
+      --ansi|--no-ansi           Force (or disable --no-ansi) ANSI output
+  -n, --no-interaction           Do not ask any interactive question
+      --env[=ENV]                The environment the command should run under
+  -v|vv|vvv, --verbose           Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
+```

--- a/docs/versions/2.4/laravel-controller-injection.md
+++ b/docs/versions/2.4/laravel-controller-injection.md
@@ -1,0 +1,65 @@
+# Laravel Controller Injection
+
+Bag can automatically inject Bag objects into your controllers using Laravel's automatic dependency injection. This can take
+the place of using Laravel's form request validation _and_ accessing the input data.
+
+```php
+use App\Values\MyValue;
+
+class MyController extends Controller {
+    public function store(MyValue $value) {
+        // $value is a validated MyValue object
+    }
+}
+```
+
+## Avoiding Extra Parameters
+
+By default, Bag will throw a `\Bag\Exceptions\AdditionalPropertiesException` exception if you try to instantiate a non-variadic Bag with extra parameters. You can disable this behavior by adding the `StripExtraParameters` attribute to the controller parameter:
+
+```php
+use App\Values\MyValue;
+use Bag\Attributes\StripExtraParameters;
+
+class MyController extends Controller {
+    public function store(
+        #[StripExtraParameters] MyValue $value
+    ) {
+        // After stripping extra parameters, $value is a validated MyValue object
+    }
+}
+```
+
+> [!TIP]
+> You can also add the `StripExtraParameters` attribute to [the Bag class itself](./basic-usage.md#stripping-extra-parameters). 
+
+## Automatic Validation 
+
+When you type hint a `Bag` object in your controller method, Bag will automatically validate the request data and inject the `Bag` object into your controller method.
+
+## Manual Validation
+
+If you want to inject the `Bag` object without validation, you can add the `WithoutValidation` attribute to the property:
+
+```php
+use App\Values\MyValue;
+use Bag\Attributes\WithoutValidation;
+
+class MyController extends Controller {
+    public function store(
+        #[WithoutValidation] MyValue $value
+    ) {
+        $value = $value->append(extra: 'data')->valid();
+        // $value is now a validated MyValue object
+    }
+}
+```
+
+> [!NOTE]
+> This will also strip additional parameters from the request data that are not part of the `Bag` object.
+
+> [!TIP]
+> The `Bag->valid()` method will throw a `ValidationException` if the Bag object is not valid by default, you can pass in `false` to return null instead.
+
+> [!CAUTION]
+> The input values must still fulfill the requirements of the Bag constructor, all required properties must be present otherwise an exception will be thrown.

--- a/docs/versions/2.4/laravel-debugbar.md
+++ b/docs/versions/2.4/laravel-debugbar.md
@@ -1,0 +1,10 @@
+---
+aside: false
+---
+# Laravel Debugbar Integration
+
+Bag supports [Laravel Debugbar](http://laraveldebugbar.com) out of the box if it is enabled. 
+
+All Bags will be available to inspect in the Debugbar automatically:
+
+![laravel-debugbar.png](/assets/images/laravel-debugbar.png)

--- a/docs/versions/2.4/laravel-eloquent-casting.md
+++ b/docs/versions/2.4/laravel-eloquent-casting.md
@@ -1,0 +1,78 @@
+# Eloquent Casting
+
+Bag supports Eloquent casting for both Bag objects and Collections.
+
+## Casting Bag Objects
+
+To cast a Bag object, use the Bag class name as the cast type in the `$casts` property of your Eloquent model:
+
+```php{7}
+use Illuminate\Database\Eloquent\Model;
+use App\Values\MyValue;
+
+class MyModel extends Model
+{
+    protected $casts = [
+        'my_value' => MyValue::class,
+    ];
+}
+```
+
+This will cast the `MyValue` object to a JSON string when saving it to the database and will cast it back to a `MyValue` object when retrieving it from the database.
+
+> [!WARNING]
+> Bag will store _all_ properties, including hidden properties.
+
+## Casting Collections
+
+For Laravel 11+, you can cast to a Collection using the `casts()` method along with the `::castAsCollection()` method on your Bag class:
+
+```php{6,8}
+use Illuminate\Database\Eloquent\Model;
+use App\Values\MyValue;
+
+class MyModel extends Model
+{
+    public function casts(): array {
+        return [
+            'my_values' => MyValue::castAsCollection(),
+        ];
+    }
+}
+```
+
+or the `AsBagCollection::of()` method:
+
+```php{7,9}
+use Illuminate\Database\Eloquent\Model;
+use App\Values\MyValue;
+use Bag\AsBagCollection;
+
+class MyModel extends Model
+{
+    public function casts(): array {
+        return [
+            'my_values' => AsBagCollection::of(MyValue::class),
+        ];
+    }
+}
+```
+
+Alternatively, for Laravel 10, you can use the `AsBagCollection` class as the cast type in the `$casts` property of your Eloquent model, passing in the Bag class name as the first argument:
+
+```php{8}
+use Illuminate\Database\Eloquent\Model;
+use App\Values\MyValue;
+use Bag\AsBagCollection;
+
+class MyModel extends Model
+{
+    protected $casts = [
+        'my_values' => AsBagCollection::class . ':' . MyValue::class,
+    ];
+}
+```
+
+Bag will cast the Collection to a JSON string when saving to the database and will cast them back to a Collection of `MyValue` objects when retrieving them from the database.
+
+Bag will automatically use the custom collection class if one is defined on the Bag class when retrieving the value.

--- a/docs/versions/2.4/laravel-route-parameter-binding.md
+++ b/docs/versions/2.4/laravel-route-parameter-binding.md
@@ -1,0 +1,111 @@
+# Laravel Route Parameter Binding
+
+Bag can automatically populate properties from Laravel Route Parameters. This can be useful when you have both a 
+Bag representing your request body, and a route parameter that you want to associate with the Bag.
+
+## Binding Route Parameters
+
+To bind a route parameter, use the `Bag\Attributes\Laravel\FromRouteParameter` attribute on the property you want to bind.
+
+For example given the following controller:
+
+```php
+use App\Values\MyValue;
+
+class MyController {
+    public function show(MyValue $bag, string $id) {
+        // $bag is automatically injected and validated
+        // $id is a route parameter
+    }
+}
+```
+
+You can create a Bag like this that will automatically populate the `id` property based on the route parameter as injected above:
+
+```php{6}
+use Bag\Attributes\Laravel\FromRouteParameter;
+use Bag\Bag;
+
+class MyValue extends Bag
+{
+    #[FromRouteParameter()]
+    public string $id;
+}
+```
+
+This will automatically populate the `id` property from the route parameter with the same name as the property.
+
+You can also use a different property name just by passing it to the attribute:
+
+```php{6}
+use Bag\Attributes\Laravel\FromRouteParameter;
+use Bag\Bag;
+
+class MyValue extends Bag
+{
+    #[FromRouteParameter('id')]
+    public string $valueId;
+}
+```
+
+This will automatically popualte the `valueId` property from the route parameter with the name `id`.
+
+## Binding Route Parameter Properties
+
+In addition to binding the entire route parameter value to a single property, you can also bind a property or array key
+from that value to your Bag using the `Bag\Attributes\Laravel\FromRouteParameterProperty` attribute.
+
+For example, given the following controller:
+
+```php
+use App\Models\User;
+use App\Values\MyValue;
+
+class MyController {
+    public function show(MyValue $bag, User $user) {
+        // $bag is automatically injected and validated
+        // $user is a route parameter
+    }
+}
+```
+
+We can map the `id` property from the `User` model to a property on the Bag like this:
+
+```php{6}
+use Bag\Attributes\Laravel\FromRouteParameter;
+use Bag\Bag;
+
+class MyValue extends Bag
+{
+    #[FromRouteParameterProperty('user')]
+    public string $id;
+}
+```
+
+This will automatically populate the `id` property with the `id` property from the `user` route parameter. 
+Alternatively, you can specify a source property name:
+
+```php{6}
+use Bag\Attributes\Laravel\FromRouteParameter;
+use Bag\Bag;
+
+class MyValue extends Bag
+{
+    #[FromRouteParameterProperty('user', 'id')]
+    public string $userId;
+}
+```
+
+This will automatically populate the property `userId` with the `id` property from the `user` route parameter.
+
+
+## Types & Casting
+
+The value from the route parameter will be cast by Laravel to the type specified in the controller method,
+and will then be cast to the type of the property in the Bag if necessary.
+
+For example, if the route parameter method argument is an integer, and the property is a string, the integer will be cast to a string.
+However, if the route parameter is an eloquent model and the property is also the same eloquent model, the value will not be cast.
+
+> [!TIP]
+> This works great for route model binding!

--- a/docs/versions/2.4/mapping.md
+++ b/docs/versions/2.4/mapping.md
@@ -1,0 +1,191 @@
+# Mapping
+
+Bag allows you to map both input names to properties, and properties to output names. This is useful when
+transforming JSON `snake_case` to your codes `camelCase` and vice-versa.
+
+## How Mapping Works
+
+Mapping should be thought of as aliasing property names. The input mapper determines what the _incoming_ aliases _could_ be by transforming the original property name, while the output mapper transform the property name and uses it for the _outgoing_ property name. This means
+that if you want to map a `propertyName` from the input `property_name` you would use a `SnakeCase` mapper, rather than a `camelCase` mapper.
+
+## Mapping Names
+
+To map names use the `Bag\Attributes\MapName`, `Bag\Attributes\MapInputName`, or `Bag\Attributes\MapOutputName` attributes. These attributes can either be applied to the entire class, **or** to an individual property.
+
+### Class-level Mapping
+
+Class-level mapping applies to all properties on the class. This is useful when all properties on a class should be mapped in the same way.
+
+This is done by applying the mapper attribute to the class:
+
+```php{5,6}
+use Bag\Bag;
+use Bag\Attributes\MapName;
+use Bag\Mappers\SnakeCase;
+
+#[MapInputName(SnakeCase::class)
+#[MapOutputName(SnakeCase::class)]
+class MyValue extends Bag {
+    public function __construct(
+        public string $myValue,
+        public string $myOtherValue
+    ) {}
+}
+```
+
+> [!NOTE]
+> The above is functionally equivelent to using:
+> ```php
+> #[MapName(input: SnakeCase::class, output: SnakeCase::class)]
+> ```
+> 
+> We recommend using the `MapInputName` and `MapOutputName` attributes as mapper arguments can be passed 
+> directly, rather than as an array of values to either the `inputParams` and/or `outputParams` arguments:
+> 
+> ```php
+> #[MapInputName(MapperName::class, 'param1', 'param2')]
+> #[MapOutputName(MapperName::class, 'param1', 'param2')]
+> 
+> // vs
+> 
+> #[MapName(input: MapperName::class, inputParams: ['param1', 'param2'], output: MapperName::class, outputParams: ['param1', 'param2'])]
+> ```
+
+In this above example, the `MyValue` class will map _all_ property names from `snake_case` to `camelCase` on both input and output, in this case, `my_value` to `myValue` and `my_other_value` to `myOtherValue`:
+
+```php
+$value = MyValue::from([
+    'my_value' => 'value',
+    'my_other_value' => 'other value'
+]);
+```
+
+In addition to the mapped names, you can still use the original property names:
+
+```php
+$value = MyValue::from([
+    'myValue' => 'value',
+    'myOtherValue' => 'other value'
+]);
+```
+
+> [!TIP]
+> You can specify a mapper on either the class or property level, or both. If you specify a mapper on both the class and property level, the property-level mapper will take precedence.
+
+## Built-in Mappers
+
+Bag comes with a few built-in mappers:
+
+- `SnakeCase` - Converts property names to/from `snake_case`
+- `CamelCase` - Converts property names to/from `camelCase`
+- `Alias` - Allows you to specify a custom alias for a specific property name
+- `Stringable` - Converts property names using a sequence of [fluent string helper methods](https://laravel.com/docs/12.x/strings#fluent-strings-method-list).
+
+### Using the Alias Mapper
+
+The `Alias` mapper allows you to specify a custom alias for a specific property name. 
+
+> [!WARNING]
+> Unlike other mappers, the `Alias` mapper **must** only be applied to individual properties.
+
+In the following example we alias the input name `uuid` to the property `id`:
+
+```php{7}
+use Bag\Bag;
+use Bag\Attributes\MapInputName;
+use Bag\Mappers\Alias;
+
+class MyValue extends Bag {
+    public function __construct(
+        #[MapInputName(Alias::class, 'uuid')])]
+        public string $id,
+    ) {}
+}
+````
+
+### Using the Stringable Mapper
+
+The `Stringable` mapper allows you to chain any of the [fluent string helper methods](https://laravel.com/docs/12.x/strings#fluent-strings-method-list) to convert property names.
+
+The `Stringable` mapper accepts any number of transformations. To pass in arguments to a given transformation, use a colon `:` followed by a comma-separated list of arguments.
+
+```php{4,5}
+use Bag\Bag;
+use Bag\Mappers\Stringable;
+
+#[MapInputName(Stringable::class, 'camel', 'kebab')]
+#[MapOutputName(Stringable::class, 'camel', 'kebab')]
+class MyValue extends Bag {
+    public function __construct(
+        public string $myValue,
+        public string $myOtherValue
+    ) {}
+}
+```
+
+## When Mapping Applies
+
+Input mapping is applied when calling `Bag::from()` or `Bag::withoutValidation()`. You can use either the original property name _or_ the mapped name when creating a Bag.
+
+> [!TIP]
+> [Validation](./validation) is applied to the original property name, not the mapped name.
+
+Output mapping is applied when calling `$Bag->toArray()`, `$Bag->toCollection()`, or `$Bag->toJson()` (or when using `json_encode()`).
+
+## Mapping Hierarchy
+
+For input mapping, _all_ mappers are used, allowing _multiple_ mapped names to match to the same property. **The last _incoming_
+property name that matches will be the value used for the Bag.**
+
+The mapping hierarchy is as follows:
+
+- Class Level: `MapName(input)`
+  - Class Level: `MapInputName`
+    - Property Level: `MapName(input)`
+      - Property Level: `MapInputName`
+
+For output mapping, _only_ the last mapper is used. The mapping hierarchy is as follows:
+
+- Class Level: `MapName(output)`
+  - Class Level: `MapOutputName`
+    - PropertyLevel Level: `MapName(Output)`
+      - PropertyLevel Level: `MapOutputName`
+
+> [!NOTE]
+> The `MapName` and `MapOutputName` attributes can only be added once at each level. You can add as many `MapInputName` attributes as you like!
+
+## Custom Mappers
+
+You can also create your own mappers by implementing the `\Bag\Mappers\MapperInterface` interface.
+
+```php
+use Bag\Mappers\MapperInterface;
+use Illuminate\Support\Str;
+
+class Kebab implements MapperInterface {
+    public function input(string $name): string {
+        return Str::of($name)->camel()->kebab();
+    }
+
+    public function output(string $name): string {
+        return Str::of($name)->camel()->kebab();
+    }
+}
+```
+
+Then specify it in the Mapping attribute:
+
+```php{5,6}
+use \App\Values\Mappers\Kebab;
+use Bag\Bag;
+use Bag\Mappers\Stringable;
+
+#[MapInputName(Kebab::class)]
+#[MapOutputName(Kebab::class)]
+class MyValue extends Bag {
+    public function __construct(
+        public string $myValue,
+        public string $myOtherValue
+    ) {}
+}
+```

--- a/docs/versions/2.4/object-to-bag.md
+++ b/docs/versions/2.4/object-to-bag.md
@@ -1,0 +1,55 @@
+# Creating Bags From Objects
+
+Bag provides an easy way to create Bags from objects with the `Bag\Traits\HasBag` trait. 
+
+This trait provides a `->toBag()` method that converts the object into a Bag object using the Bag class
+defined in the `Bag\Attributes\Bag` class attribute.
+
+## Adding `HasBag` To Your Class
+
+```php{5,7}
+use App\Values\MyValue;
+use Bag\Attributes\Bag;
+use Bag\Traits\HasBag;
+
+#[Bag(MyValue::class)]
+class MyClass {
+    use HasBag;
+    
+    // ... 
+} 
+```
+
+Once you have made these changes to your class, you can easily create a Bag object from an instance of your class by calling the `->toBag()` method:
+
+```php
+$myClass = new MyClass();
+$bag = $myClass->toBag();
+```
+
+## Property Visibility
+
+By default, the `Bag\Traits\HasBag` trait will only include public properties in the Bag object. If you would like to include protected and private properties, you can pass the `visibility` argument to the `Bag\Attributes\Bag` attribute.
+
+The visibility property is a bitmask of the following values:
+
+- `Bag\Attributes\Bag::PUBLIC` - Include public properties
+- `Bag\Attributes\Bag::PROTECTED` - Include protected properties
+- `Bag\Attributes\Bag::PRIVATE` - Include private properties
+- `Bag\Attributes\Bag::ALL` - Include all properties
+
+```php{5}
+use App\Values\MyValue;
+use Bag\Attributes\Bag;
+use Bag\Traits\HasBag;
+
+#[Bag(MyValue::class, Bag::PUBLIC | Bag::PROTECTED)]
+class MyClass {
+    use HasBag;
+    
+    // ... 
+} 
+```
+
+> [!TIP]
+> You can also specify the visibility when calling the `->toBag()` method e.g. `$myClass->toBag(Bag::ALL)`

--- a/docs/versions/2.4/output.md
+++ b/docs/versions/2.4/output.md
@@ -1,0 +1,30 @@
+# Output
+
+Once you have created a Bag value object, you can access the properties using object notation:
+
+```php
+use App\Values\MyValue;
+
+$value = new MyValue(name: 'Davey Shafik', age: 40);
+$value->name; // 'Davey Shafik'
+```
+
+## Casting to Other Types
+
+Bag supports casting to arrays and [`\Bag\Collections`](./collections.md##extending-laravel-collections) using the
+`Bag->toArray()` and `Bag->toCollection()` methods.
+
+Both methods will apply casting and mapping, as well as respect [hidden properties](./hidden).
+
+## JSON Serialization
+
+In addition, you can serialize a Bag object to JSON using `json_encode()` or `Bag->toJson():
+
+```php
+$value = MyValue::from(name: 'Davey Shafik', age: 40);
+
+$value->toJson(); // {"name": "Davey Shafik", "age": 40}
+json_encode($value, JSON_THROW_ON_ERROR); // {"name": "Davey Shafik", "age": 40}
+```
+
+Both `Bag->toJson()` and `json_encode()` will respect [hidden properties](./hidden).

--- a/docs/versions/2.4/testing.md
+++ b/docs/versions/2.4/testing.md
@@ -1,0 +1,157 @@
+# Testing
+
+Bag supports Factories to make creating test values easier. Bag factories are similar to [Eloquent factories](https://laravel.com/docs/12.x/eloquent-factories), but they are used to create Bag objects.
+
+## Creating a Factory
+
+Factories extend the `Bag\Factory` class, and define a `definition()` method that returns an array of default values for the value object.
+
+```php
+use Bag\Factory;
+
+class MyValueFactory extends Factory {
+    #[Override]
+    public function definition(): array {
+        return [
+            'name' => 'Davey Shafik',
+            'age' => 40,
+        ];
+    }
+}
+```
+
+### Faker Integration
+
+Factories include [Faker](https://fakerphp.org) support out of the box. You can use the `$faker` property to generate random values:
+
+```php
+return [
+    'name' => $this->faker->name(),
+    'age' => $this->faker->numberBetween(18, 65),
+];
+```
+
+> [!TIP]
+> You can also generate factory classes automatically using the [`artisan make:bag`](./laravel-artisan-make-bag-command) command.
+
+## Using a Factory
+
+Before you can use a Factory, you must first add both the `Factory` attribute and the `HasFactory` trait to your Bag object:
+
+```php{5,7}
+use Bag\Attributes\Factory;
+use Bag\Bag;
+use Bag\Traits\HasFactory;
+
+#[Factory(MyValueFactory::class)]
+class MyValue extends Bag {
+    use HasFactory;
+    
+    public function __construct(
+        public string $name,
+        public int $age,
+    ) {}
+}
+```
+
+You can now use the factory to create a new instance of the value object:
+
+```php
+$bag = MyValue::factory()->make();
+```
+
+This will create a new `MyValue` object using the factory definition.
+
+## Customizing Factory State
+
+You can also specify custom values when creating a factory, which will override the factory definition. You can pass the values to the `::factory()` call itself,
+using the `->state()` method on the factory, or by passing it to the `->make()` method.
+
+```php
+// All three are identical:
+
+$value = MyValue::factory([
+    'name' => 'Taylor Otwell',
+])->make();
+
+$value = MyValue::factory()->make([
+    'name' => 'Taylor Otwell',
+]);
+
+$value = MyValue::factory()->state([
+    'name' => 'Taylor Otwell',
+])->make();
+```
+
+## Named States
+
+Bag supports named states, which allow you to modify the state of the value object when creating it:
+
+```php
+use Bag\Factory;
+
+class MyValueFactory extends Factory {
+    public function definition(): array {
+        return [
+            'name' => 'Davey Shafik',
+            'age' => 40,
+        ];
+    }
+
+    public function withName(string $name): static {
+        return $this->state([
+            'name' => $name,
+        ]);
+    }
+}
+```
+
+You can now use the state when creating the value object:
+
+```php
+$bag = MyValue::factory()->withName($faker->name())->make();
+```
+
+## Creating Collections of Bag Values
+
+You can use the `->count()` method to create a collection of Bag objects:
+
+```php
+$values = MyValue::factory()->count(10)->make();
+```
+
+This will create a `Bag\Collection` of 10 identical `MyValue` objects.
+
+> [!TIP]
+> If your Bag object has a `Collection` attribute, `->make()` will return an instance of that collection class.
+
+## Sequences
+
+Bag factories support Eloquent factory Sequences to generate unique values for each instance in a collection.
+
+```php
+use Illuminate\Database\Eloquent\Factories\Sequence;
+
+$bag = MyValue::factory()->count(10)->sequence(fn(Sequence $sequence) => [
+    'name' => 'Person #' . $sequence->index,
+    'age' => 18 + $sequence->index,
+])->make();
+```
+
+In this example, the `name` property will be set to `Person #1`, `Person #2`, etc., and the `age` property will be set to `19`, `20`, etc.
+
+The `->sequence()` method accepts any of the following:
+
+- A `Illuminate\Database\Eloquent\Factories\Sequence` instance created with a `closure` that returns an array of values
+- A `Illuminate\Database\Eloquent\Factories\Sequence` instance created with a variadic number of arrays of values
+- A `closure` value that returns an array of values
+- A variadic number of arrays of values
+
+You may also pass a `Sequence` object to the `->state()` method.
+
+> [!TIP]
+> If you create more values than number of value arrays passed in, the sequence will start over from the beginning.
+
+> [!WARNING]
+> If you use both states (named or via the `::factory()`, `->state()`, or `->make()` methods) and sequences, sequences will be applied _after_ the state, so the sequences will override any values set by the state.
+

--- a/docs/versions/2.4/transformers.md
+++ b/docs/versions/2.4/transformers.md
@@ -1,0 +1,102 @@
+# Transformers
+
+Transformers are helpers that transform Bag input data from custom types, e.g. Models or JSON strings.
+
+## Using Transformers
+
+Transformers are methods defined on your Bag class that transform input data into the correct type. Transformers are
+identified by adding the `Transforms` attribute to the method, passing the type you want to transform from.
+
+For example, to transform from a JSON string:
+
+```php
+use Bag\Bag;
+
+class MyValue extends Bag
+{
+    #[Transforms('string')]
+    protected static function fromJsonString(string $json): array
+    {
+        return json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+    }
+}
+```
+
+or to transform from a specific class:
+
+```php
+use App\Models\User;
+use Bag\Bag;
+
+class MyValue extends Bag
+{
+    #[Transforms(User::class)]
+    protected static function fromUser(User $user): array
+    {
+        return $user->toArray();
+    }
+}
+```
+
+You can pass multiple types to the `Transforms` attribute, or use multiple `Transforms` attributes to handle multiple types.
+
+The following two examples are functionally the same:
+
+```php
+use App\Models\Book;
+use App\Models\Magazine;
+use Bag\Bag;
+
+class MyValue extends Bag
+{
+    #[Transforms(Book::class)]
+    #[Transforms(Magazine::class)]
+    protected static function fromMedia(Book|Magazine $media): array
+    {
+        return $media->toArray();
+    }
+}
+```
+
+and:
+
+```php
+use App\Models\Book;
+use App\Models\Magazine;
+use Bag\Bag;
+
+class MyValue extends Bag
+{
+    #[Transforms(Book::class, Magazine::class)]
+    protected static function fromMedia(Book|Magazine $media): array
+    {
+        return $media->toArray();
+    }
+}
+```
+
+Bag will match child classes to their parents, so `Transforms(Model::class)` will match any child `Model` objects, however,
+if there is a more specific transformer available, Bag will use that instead.
+
+> [!TIP]
+> Bag will use the most specific transformer available, if two or more transformers are equally specific then Bag will use the first one it finds.
+
+### Handling JSON
+
+By default, Bag will transform JSON strings, but you can override this behavior by defining a overriding the `fromJsonString` method:
+
+```php
+use Bag\Bag;
+
+class MyValue extends Bag
+{
+    #[Transforms(Bag::FROM_JSON)]
+    protected static function fromJsonString(string $json): array
+    {
+        return json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+    }
+}
+```
+
+To differentiate between other strings and JSON, you should use the special type `Bag::FROM_JSON` as the `Transformer` type.
+

--- a/docs/versions/2.4/upgrading.md
+++ b/docs/versions/2.4/upgrading.md
@@ -1,0 +1,50 @@
+# Upgrading to Bag 2
+
+This guide will help you upgrade your application from Bag 1.x to Bag 2.x.
+
+## Casting with Union Types
+
+To support union types fully, the `\Bag\Casts\CastsPropertySet::set()` method signature has changed the first argument from:
+
+```php
+public function set(string $propertyType, string $propertyName, \Illuminate\Support\Collection $properties): mixed
+```
+
+to:
+
+```php
+public function set(\Bag\Collection $propertyTypes, string $propertyName, \Illuminate\Support\Collection $properties): mixed
+```
+
+This change allows for union types to be passed in as a collection of types (as string type names). Your return value must match one of the types in the collection.
+
+## Legacy Behavior
+
+In Bag 1.x the first type in the union was used to cast the property. To update your code and retain the previous behavior, you will want to do the following:
+
+```diff
+- public function set(string $propertyType, string $propertyName, \Illuminate\Support\Collection $properties): mixed
+- {
++ public function set(\Bag\Collection $propertyTypes, string $propertyName, \Illuminate\Support\Collection $properties): mixed
++ {
++       $propertyType = $propertyTypes->first();
+```
+
+## Fill Nullables
+
+The behavior when instantiating a Bag has changed such that arguments that are nullable _without_ a default value are filled with nulls.
+Previously, this would have caused exception to be thrown. This solves for a common scenario when you are filling a Bag from user input.
+
+```php
+readonly class MyBag extends Bag {
+    public function __construct(
+         public ?string $name
+    }
+}
+
+// Bag 1.4.0 (and older)
+MyBag::from([]); // throws MissingPropertiesException
+
+// Bag 2.0.0+
+MyBag::from([]); // MyBag { $name = null }
+```

--- a/docs/versions/2.4/validation.md
+++ b/docs/versions/2.4/validation.md
@@ -59,10 +59,6 @@ $value = MyValue::withoutValidation([
 ]);
 ```
 
-## Validation Optionals
-
-See [Optionals](./optionals#validation) for information on how to use validation with optional properties.
-
 ## Built-in Validation Attributes
 
 Bag provides a number of built-in validation attributes, based on various Laravel validation rules:

--- a/docs/versions/2.4/variadics.md
+++ b/docs/versions/2.4/variadics.md
@@ -1,0 +1,63 @@
+# Variadic Properties
+
+Bag supports the use of [Variadic](https://www.php.net/manual/en/functions.arguments.php#functions.variable-arg-list) arguments.
+
+Variadic arguments **must** be manually assigned to a property:
+
+```php
+use Bag\Bag;
+
+class MyValue extends Bag {
+    public $values;
+
+    public function __construct(mixed ...$values) {
+        $this->values = $values;
+    }
+}
+```
+
+## Casting
+
+Bag will automatically cast variadic values to their defined typed:
+
+```php
+use Bag\Bag;
+
+class MyValue extends Bag {
+    public $values;
+
+    public function __construct(bool ...$values) {
+        $this->values = $values;
+    }
+}
+```
+
+The above example will cast all values to `bool`:
+
+```php
+$bag = new MyValue(true, false, 0, 1);
+
+// $bag->values = [true, false, false, true]
+```
+
+You can also use `Cast` attributes to cast the values:
+
+```php
+use Bag\Bag;
+use Bag\Casts\DateTime;
+use Carbon\CarbonImmutable;
+
+class MyValue extends Bag {
+    public $values;
+
+    public function __construct(
+        #[Cast(DateTime::class, format: 'Y-m-d')]
+        CarbonImmutable ...$values
+    ) {
+        $this->values = $values;
+    }
+}
+```
+
+This will cast all input values to `CarbonImmutable` instances, using the `Y-m-d` format.
+

--- a/docs/versions/2.4/whats-new.md
+++ b/docs/versions/2.4/whats-new.md
@@ -1,0 +1,7 @@
+# What's New in Bag 2.4
+
+## Laravel DebugBar
+
+Bag 2.4 adds automatic support for Laravel DebugBar. If you have DebugBar enabled, all Bags will be available to inspect in the DebugBar automatically.
+
+Read more in the [documentation](./laravel-debugbar).

--- a/docs/versions/2.4/why.md
+++ b/docs/versions/2.4/why.md
@@ -1,0 +1,65 @@
+# Why Choose Bag?
+
+Bag is a simple, lightweight, modern, and flexible library for working with value objects in PHP. 
+
+It is designed to be easy to use, with a minimal API that is easy to understand and use.
+
+Bag focuses on immutability and type safety.
+
+## Compared to spatie/laravel-data
+
+Bag was heavily inspired by the excellent [spatie/laravel-data](https://spatie.be/docs/laravel-data/) package, and as such
+should feel very familiar to anyone who has used it — _however_, it has several key differences.
+
+## Common Features
+
+- [Value Casting](./casting) (both in and out, although spatie/laravel-data calls outbound casting Transforming)
+  - Including nested Bag objects
+- [Name Mapping](./mapping) (both in and out) at the class and property level
+- [Validation](./validation) (although spatie/laravel-data does not support all Laravel validation options easily)
+- [Collections](./collections) of Value Objects[*](#collections)
+- [Object to Bag](./object-to-bag) conversion
+- [Wrapping](./wrapping) of output arrays/JSON
+- [Eloquent Casting](./laravel-eloquent-casting)
+- [Laravel Controller Injection](./laravel-controller-injection)
+
+## Immutability
+
+Bag is immutable by default. 
+
+spatie/laravel-data does not support immutable value objects, and as of PHP 8.3, there is no reasonable way to make them immutable.
+
+## Factory Support
+
+Bag [factories](./testing) support most of the rich features and simple UX of Laravel Model Factories except for the `create()` method (as value objects do not feature persistence). 
+This includes support for [factory states](https://laravel.com/docs/12.x/eloquent-factories#factory-states) and [sequences](https://laravel.com/docs/12.x/eloquent-factories#sequences).
+
+spatie/laravel-data v3 does not support factories, while v4 has [rudimentary support](https://spatie.be/docs/laravel-data/v4/as-a-data-transfer-object/factories).
+
+## Variadic Support
+
+Bag supports the use of [Variadic](./variadics) during value object creation. 
+
+## Collections
+
+Bag uses Laravel Collections as the basis for its [Collection](./collections) classes, and supports them wherever Collections are used, however `Bag\Collection` is an immutable-safe variant that we recommend
+using whenever possible. 
+
+spatie/laravel-data v3 uses a custom `DataCollection` class that is not based on Laravel collections and lacks many Collection features. v4 uses Laravel Collections, although it still 
+has [custom collection classes](https://spatie.be/docs/laravel-data/v4/as-a-data-transfer-object/collections) with varying levels of compatibility with Laravel Collections.
+
+## Hidden Properties
+
+Bag supports [hiding properties](./hidden) when transforming to an array and/or JSON.
+
+## Artisan `make:bag` Command
+
+Bag supports an [artisan command](./laravel-artisan-make-bag-command) for creating new Bag classes, including support for creating factories and collections.
+
+## Other Differences
+
+In addition to the above, Bag has a few other minor differences:
+
+- [Casters](./casting) apply to both incoming values and outgoing values, while spatie/laravel-data splits these into two difference concepts.
+- Input from complex values uses [Transformers](./transformers), which are more explicit in Bag, while spatie/laravel-data uses a more implicit approach with magic methods e.g. `::fromModel()`
+- Simpler attribute names: `Cast` vs `WithCast` and `WithTransformer`

--- a/docs/versions/2.4/wrapping.md
+++ b/docs/versions/2.4/wrapping.md
@@ -1,0 +1,76 @@
+# Wrapping Outputs
+
+Bag supports wrapping both Bag values and Collections when transforming to an array or JSON.
+
+## Wrapping Bags
+
+To wrap a Bag, add the `Bag\Attributes\Wrap` or `Bag\Attributes\WrapJson` attribute to the class:
+
+```php{4}
+use Bag\Attributes\Wrap;
+use Bag\Bag;
+
+#[Wrap('data')]
+class MyValue extends Bag {
+    public function __construct(
+        public string $name,
+        public int $age,
+    ) {}
+}
+```
+
+Now whenever you call `->toArray()` or serialize to JSON, the output will be wrapped in a key of `data`:
+
+```php
+$myValue = MyValue::from(['name' => 'Davey Shafik', 'age' => 40]);
+$myValue->toArray(); // ['data' => ['name' => 'Davey Shafik', 'age' => 40]]
+$myValue->toJson(); // {"data":{"name":"Davey Shafik","age":40}}
+```
+
+If you only want to wrap when serializing to JSON, you can use the `WrapJson` attribute instead:
+
+```php{4}
+use Bag\Attributes\WrapJson;
+use Bag\Bag;
+
+#[WrapJson('data')]
+class MyValue extends Bag {
+    public function __construct(
+        public string $name,
+        public int $age,
+    ) {}
+}
+```
+
+Now when you serialize to JSON, the values will be wrapped, but when calling `->toArray()` the output will not be wrapped
+
+```php
+$myValue = MyValue::from(['name' => 'Davey Shafik', 'age' => 40]);
+$myValue->toArray(); // ['name' => 'Davey Shafik', 'age' => 40]
+$myValue->toJson(); // {"data":{"name":"Davey Shafik","age":40}}
+```
+
+> [!TIP]
+> You can add both `Wrap` and `WrapJson` attributes to the same class to apply different wrapping to `->toArray()` and JSON serialization respectively.
+
+## Wrapping Collections
+
+Wrapping Collections works exactly the same way as with Bags: add the `Bag\Attributes\Wrap` or `Bag\Attributes\WrapJson` attribute to the Collection class:
+
+```php{4}
+use Bag\Attributes\Wrap;
+use Bag\Collection;
+
+#[Wrap('data')]
+class MyCollection extends Collection {
+}
+```
+
+Now when you call `->toArray()` or serialize to JSON, the output will be wrapped in a key of `data`:
+
+```php
+$collection = MyValue::factory()->count(2)->make();
+
+$collection->toArray(); // ['data' => [["name" => "Davey Shafik", "age" => 40], ...]]
+$collection->toJson(); // {"data":[{"name":"Davey Shafik","age":40}, ...]}
+```

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -1,7 +1,44 @@
-# What's New in Bag 2.4
+# What's New in Bag 2.5
 
-## Add Support for Laravel DebugBar
+## Optional Properties
 
-Bag 2.4 adds automatic support for Laravel DebugBar. If you have DebugBar enabled, all Bags will be available to inspect in the DebugBar automatically.
+Bag 2.5 adds support for optional properties using the `Optional` class. This allows you to define properties that can be omitted when creating a Bag object.
 
-Read more in the [documentation](./laravel-debugbar).
+Optional properties will _also_ be omitted when outputting the Bag object as an array or JSON.
+
+```php
+use Bag\Bag;
+
+class MyValue extends Bag
+{
+    public function __construct(
+        public string $name,
+        public Optional|int $age,
+        public Optional|string|null $email = null,
+    ) {}
+}
+
+$value = new MyValue(name: 'Davey Shafik', email: null);
+$value->toArray(); // ['name' => 'Davey Shafik', 'email' => null]
+$value->toJson(); // {"name": "Davey Shafik", "email": null}
+```
+
+Read more in the [documentation](./optionals).
+
+## Nullable `DateTimeInterface` properties
+
+Prior to Bag 2.5, if you had a nullable `DateTimeInterface` property (e.g. `?\Carbon\CarbonImmutable`) it would attempt to create the
+`DateTimeInterface` object with `null` and fail with a `TypeError`. Bag 2.5 will instead assign the value to `null`.
+
+```php
+use Bag\Bag;
+
+class MyValue extends Bag
+{
+    public function __construct(
+        public ?DateTimeInterface $date = null,
+    ) {}
+}
+
+$value = new MyValue(date: null); // Bag < 2.5 TypeError, 2.5+ sets null
+```

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,7 +4,7 @@
          bootstrap="vendor/autoload.php"
          cacheDirectory=".phpunit.cache"
          executionOrder="random"
-         requireCoverageMetadata="false"
+         requireCoverageMetadata="true"
          beStrictAboutCoverageMetadata="false"
          beStrictAboutOutputDuringTests="true"
          failOnRisky="false"

--- a/src/Bag/Bag.php
+++ b/src/Bag/Bag.php
@@ -8,6 +8,7 @@ use Bag\Concerns\WithArrayable;
 use Bag\Concerns\WithCollections;
 use Bag\Concerns\WithEloquentCasting;
 use Bag\Concerns\WithJson;
+use Bag\Concerns\WithOptionals;
 use Bag\Concerns\WithOutput;
 use Bag\Concerns\WithValidation;
 use Bag\Pipelines\InputPipeline;
@@ -30,6 +31,7 @@ readonly class Bag implements Arrayable, Jsonable, JsonSerializable, Castable
     use WithCollections;
     use WithEloquentCasting;
     use WithJson;
+    use WithOptionals;
     use WithOutput;
     use WithValidation;
 

--- a/src/Bag/Concerns/WithOptionals.php
+++ b/src/Bag/Concerns/WithOptionals.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bag\Concerns;
+
+use Bag\Values\Optional;
+
+trait WithOptionals
+{
+    public function has(string $key): bool
+    {
+        return (isset($this->{$key}) || $this->{$key} === null) && !($this->{$key} instanceof Optional);
+    }
+
+    public function hasAny(string ...$keys): bool
+    {
+        foreach ($keys as $key) {
+            if ($this->has($key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function hasAll(string ...$keys): bool
+    {
+        foreach ($keys as $key) {
+            if (!$this->has($key)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Bag/Exceptions/ValidatorNotFoundException.php
+++ b/src/Bag/Exceptions/ValidatorNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bag\Exceptions;
+
+use Exception;
+
+class ValidatorNotFoundException extends Exception
+{
+}

--- a/src/Bag/Internal/Validator.php
+++ b/src/Bag/Internal/Validator.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bag\Internal;
+
+use Bag\Exceptions\ValidatorNotFoundException;
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Application;
+use Illuminate\Support\Collection;
+use Illuminate\Translation\FileLoader;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\Factory;
+use Illuminate\Validation\PresenceVerifierInterface;
+
+class Validator
+{
+    /**
+     * @param array<string, mixed> $values
+     * @param Collection<string, string|ValidationRule> $rules
+     */
+    public static function validate(array $values, Collection $rules): void
+    {
+        try {
+            if (class_exists(Validator::class)) {
+                /** @var object|null $validator */
+                $validator = \Illuminate\Support\Facades\Validator::getFacadeRoot();
+                if ($validator !== null && method_exists($validator, 'make')) {
+                    $validator = \Illuminate\Support\Facades\Validator::make($values, $rules->toArray());
+                    $validator->validate();
+                } else {
+                    throw new ValidatorNotFoundException();
+                }
+            }
+        } catch (BindingResolutionException|ValidatorNotFoundException) {
+            $validator = Cache::remember(__METHOD__, 'validator', function () {
+                $filesystem = new Filesystem();
+                $loader = new FileLoader($filesystem, [
+                    __DIR__ . '/../../../vendor/laravel/framework/src/Illuminate/Translation/lang',
+                    __DIR__ . '/../../../../vendor/laravel/framework/src/Illuminate/Translation/lang',
+                    __DIR__ . '/../../../../../vendor/laravel/framework/src/Illuminate/Translation/lang',
+                    __DIR__ . '/../../../../../../vendor/laravel/framework/src/Illuminate/Translation/lang',
+                ]);
+                $translator = new Translator($loader, 'en');
+
+                $validator = new Factory($translator);
+
+                if (class_exists(Application::class)) {
+                    $app = Application::getInstance();
+                    if ($app->has('db')) {
+                        /** @var PresenceVerifierInterface $presenceVerifier */
+                        $presenceVerifier = $app->get('validation.presence');
+                        $validator->setPresenceVerifier($presenceVerifier);
+                    }
+                }
+
+                return $validator;
+            });
+
+            $validator->validate($values, $rules->toArray());
+        }
+    }
+}

--- a/src/Bag/Pipelines/InputPipeline.php
+++ b/src/Bag/Pipelines/InputPipeline.php
@@ -11,6 +11,7 @@ use Bag\Pipelines\Pipes\DebugCollection;
 use Bag\Pipelines\Pipes\ExtraParameters;
 use Bag\Pipelines\Pipes\FillBag;
 use Bag\Pipelines\Pipes\FillNulls;
+use Bag\Pipelines\Pipes\FillOptionals;
 use Bag\Pipelines\Pipes\IsVariadic;
 use Bag\Pipelines\Pipes\LaravelRouteParameters;
 use Bag\Pipelines\Pipes\MapInput;
@@ -38,9 +39,10 @@ class InputPipeline
             new ProcessParameters(),
             new ProcessArguments(),
             new IsVariadic(),
-            new FillNulls(),
             new MapInput(),
             new LaravelRouteParameters(),
+            new FillOptionals(),
+            new FillNulls(),
             new MissingProperties(),
             new ExtraParameters(),
             new StripExtraParameters(),

--- a/src/Bag/Pipelines/OutputPipeline.php
+++ b/src/Bag/Pipelines/OutputPipeline.php
@@ -7,6 +7,7 @@ namespace Bag\Pipelines;
 use Bag\Pipelines\Pipes\CastOutputValues;
 use Bag\Pipelines\Pipes\GetValues;
 use Bag\Pipelines\Pipes\HideJsonValues;
+use Bag\Pipelines\Pipes\HideOptionalValues;
 use Bag\Pipelines\Pipes\HideValues;
 use Bag\Pipelines\Pipes\MapOutput;
 use Bag\Pipelines\Pipes\ProcessParameters;
@@ -29,6 +30,7 @@ class OutputPipeline
             new GetValues(),
             new HideValues(),
             new HideJsonValues(),
+            new HideOptionalValues(),
             new CastOutputValues(),
             new MapOutput(),
             new Wrap(),

--- a/src/Bag/Pipelines/Pipes/HideOptionalValues.php
+++ b/src/Bag/Pipelines/Pipes/HideOptionalValues.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bag\Pipelines\Pipes;
+
+use Bag\Pipelines\Values\BagOutput;
+use Bag\Values\Optional;
+
+readonly class HideOptionalValues
+{
+    public function __invoke(BagOutput $output): BagOutput
+    {
+        $output->values = $output->values->filter(function (mixed $value) {
+            return !($value instanceof Optional);
+        });
+
+        return $output;
+    }
+}

--- a/src/Bag/Pipelines/Pipes/Transform.php
+++ b/src/Bag/Pipelines/Pipes/Transform.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Str;
 use ReflectionAttribute;
 use ReflectionMethod;
 use ReflectionNamedType;
+use ReflectionUnionType;
 use TypeError;
 
 readonly class Transform
@@ -87,7 +88,12 @@ readonly class Transform
         if (is_array($inputs) || is_iterable($inputs) || $inputs instanceof ArrayAccess || $inputs instanceof Arrayable || is_iterable($inputs)) {
             /** @var ReflectionNamedType $parameterType */
             $parameterType = Reflection::getConstructor($input->bagClassname)?->getParameters()[0]->getType();
-            if ($parameterType->getName() === 'array') {
+            // @phpstan-ignore-next-line
+            if ($parameterType instanceof ReflectionUnionType && collect($parameterType->getTypes())->map(fn (ReflectionNamedType $type) => $type->getName())->contains('array')) {
+                return $input;
+            }
+
+            if ($parameterType instanceof ReflectionNamedType && $parameterType->getName() === 'array') {
                 return $input;
             }
 

--- a/src/Bag/Pipelines/Pipes/Validate.php
+++ b/src/Bag/Pipelines/Pipes/Validate.php
@@ -6,18 +6,11 @@ namespace Bag\Pipelines\Pipes;
 
 use BackedEnum;
 use Bag\Bag;
-use Bag\Internal\Cache;
+use Bag\Internal\Validator as ValidatorAlias;
 use Bag\Pipelines\Values\BagInput;
 use Bag\Property\Value;
-use Illuminate\Contracts\Container\BindingResolutionException;
-use Illuminate\Filesystem\Filesystem;
-use Illuminate\Foundation\Application;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Collection as LaravelCollection;
-use Illuminate\Support\Facades\Validator;
-use Illuminate\Translation\FileLoader;
-use Illuminate\Translation\Translator;
-use Illuminate\Validation\Factory;
-use Illuminate\Validation\PresenceVerifierInterface;
 use Illuminate\Validation\ValidationException;
 
 readonly class Validate
@@ -40,9 +33,10 @@ readonly class Validate
             return [$key => $rules];
         });
 
+        /** @var LaravelCollection<string, string|ValidationRule> $rules */
         $rules = $input->params->mapWithKeys(function (Value $property) {
             return [$property->name => $property->validators->all()];
-        })->mergeRecursive($rules)->filter();
+        })->toBase()->mergeRecursive($rules)->filter();
 
         if ($rules->isEmpty()) {
             return $input;
@@ -50,61 +44,7 @@ readonly class Validate
 
         // Within a Laravel application, we can use the Laravel Validator
         try {
-            if (class_exists(Validator::class)) {
-                /** @var object|null $validator */
-                $validator = Validator::getFacadeRoot();
-                if ($validator !== null && method_exists($validator, 'make')) {
-                    $validator = Validator::make($values, $rules->toArray());
-                    if ($validator->fails()) {
-                        if (method_exists($bagClass, 'redirect')) {
-                            /** @var string $redirect */
-                            // @phpstan-ignore argument.type
-                            $redirect = app()->call([$bagClass, 'redirect']);
-                            $validator->validateWithBag($redirect);
-                        }
-
-                        if (method_exists($bagClass, 'redirectRoute')) {
-                            /** @var BackedEnum|string $redirectRoute */
-                            // @phpstan-ignore argument.type
-                            $redirectRoute = app()->call([$bagClass, 'redirectRoute']);
-                            $validator->validateWithBag(route($redirectRoute));
-                        }
-
-                        throw new ValidationException($validator);
-                    }
-
-                    return $input;
-                }
-            }
-        } catch (BindingResolutionException) {
-        }
-
-        $validator = Cache::remember(__METHOD__, 'validator', function () {
-            $filesystem = new Filesystem();
-            $loader = new FileLoader($filesystem, [
-                __DIR__ . '/../../../vendor/laravel/framework/src/Illuminate/Translation/lang',
-                __DIR__ . '/../../../../vendor/laravel/framework/src/Illuminate/Translation/lang',
-                __DIR__ . '/../../../../../vendor/laravel/framework/src/Illuminate/Translation/lang',
-                __DIR__ . '/../../../../../../vendor/laravel/framework/src/Illuminate/Translation/lang',
-            ]);
-            $translator = new Translator($loader, 'en');
-
-            $validator = new Factory($translator);
-
-            if (class_exists(Application::class)) {
-                $app = Application::getInstance();
-                if ($app->has('db')) {
-                    /** @var PresenceVerifierInterface $presenceVerifier */
-                    $presenceVerifier = $app->get('validation.presence');
-                    $validator->setPresenceVerifier($presenceVerifier);
-                }
-            }
-
-            return $validator;
-        });
-
-        try {
-            $validator->validate($values, $rules->toArray());
+            ValidatorAlias::validate($values, $rules);
         } catch (ValidationException $exception) {
             if (method_exists($bagClass, 'redirect')) {
                 /** @var string $redirect */
@@ -125,4 +65,5 @@ readonly class Validate
 
         return $input;
     }
+
 }

--- a/src/Bag/Pipelines/ValidationPipeline.php
+++ b/src/Bag/Pipelines/ValidationPipeline.php
@@ -7,6 +7,7 @@ namespace Bag\Pipelines;
 use Bag\Bag;
 use Bag\Pipelines\Pipes\ExtraParameters;
 use Bag\Pipelines\Pipes\FillNulls;
+use Bag\Pipelines\Pipes\FillOptionals;
 use Bag\Pipelines\Pipes\IsVariadic;
 use Bag\Pipelines\Pipes\MapInput;
 use Bag\Pipelines\Pipes\MissingProperties;
@@ -29,8 +30,9 @@ class ValidationPipeline
             new Transform(),
             new ProcessParameters(),
             new IsVariadic(),
-            new FillNulls(),
             new MapInput(),
+            new FillOptionals(),
+            new FillNulls(),
             new MissingProperties(),
             new ExtraParameters(),
             new Validate(),

--- a/src/Bag/Pipelines/WithoutValidationPipeline.php
+++ b/src/Bag/Pipelines/WithoutValidationPipeline.php
@@ -10,6 +10,7 @@ use Bag\Pipelines\Pipes\ComputedValues;
 use Bag\Pipelines\Pipes\DebugCollection;
 use Bag\Pipelines\Pipes\FillBag;
 use Bag\Pipelines\Pipes\FillNulls;
+use Bag\Pipelines\Pipes\FillOptionals;
 use Bag\Pipelines\Pipes\IsVariadic;
 use Bag\Pipelines\Pipes\LaravelRouteParameters;
 use Bag\Pipelines\Pipes\MapInput;
@@ -36,9 +37,10 @@ class WithoutValidationPipeline
             new ProcessParameters(),
             new ProcessArguments(),
             new IsVariadic(),
-            new FillNulls(),
             new MapInput(),
             new LaravelRouteParameters(),
+            new FillOptionals(),
+            new FillNulls(),
             new MissingProperties(),
             new StripExtraParameters(),
             new CastInputValues(),

--- a/src/Bag/Property/ValueCollection.php
+++ b/src/Bag/Property/ValueCollection.php
@@ -21,6 +21,11 @@ class ValueCollection extends Collection
         return $this->where('allowsNull', true);
     }
 
+    public function optional(): static
+    {
+        return $this->where('optional', true);
+    }
+
     /**
      * @return Collection<string, Collection<string, string>>
      */

--- a/src/Bag/Validation/Rules/OptionalOr.php
+++ b/src/Bag/Validation/Rules/OptionalOr.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bag\Validation\Rules;
+
+use Bag\Internal\Validator;
+use Bag\Values\Optional as OptionalValue;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Illuminate\Validation\ValidationException;
+
+class OptionalOr implements ValidationRule
+{
+    public bool $implicit = true;
+
+    /**
+     * @param array<string|ValidationRule>|class-string|null $validation
+     */
+    public function __construct(protected array|string|null $validation = null)
+    {
+    }
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if ($this->validation === null || $value instanceof OptionalValue) {
+            return;
+        }
+
+        if (is_string($this->validation) && class_exists($this->validation)) {
+            if ($value instanceof $this->validation) {
+                return;
+            }
+
+            $fail("The :attribute must be an instance of $this->validation.");
+
+            return;
+        }
+
+        try {
+            /** @var Collection<string, string|ValidationRule> $rules */
+            $rules = collect(['value' => Arr::wrap($this->validation)]);
+            Validator::validate(['value' => $value], $rules);
+        } catch (ValidationException $exception) {
+            $fail($exception->errors()['value'][0]);
+        }
+    }
+}

--- a/src/Bag/Values/Optional.php
+++ b/src/Bag/Values/Optional.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bag\Values;
+
+class Optional
+{
+}

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+beforeEach()->coversNothing();
+
 arch('it does not call dd()')->expect('dd')->not->toBeUsed();
 arch('it does not call ddd()')->expect('ddd')->not->toBeUsed();
 arch('it does not call dump()')->expect('dump')->not->toBeUsed();

--- a/tests/Feature/Concerns/WithOptionalsTest.php
+++ b/tests/Feature/Concerns/WithOptionalsTest.php
@@ -33,3 +33,45 @@ test('has returns true with value', function () {
      ->and($bag->has('email'))
          ->toBeTrue();
 });
+
+test('hasAny returns false with optionals', function () {
+    $bag = BagWithOptionals::from(['name' => 'Davey Shafik']);
+
+    expect($bag->hasAny('age', 'email'))
+        ->toBeFalse();
+});
+
+test('hasAny returns true with null', function () {
+    $bag = BagWithOptionals::from(['name' => 'Davey Shafik', 'email' => null]);
+
+    expect($bag->hasAny('age', 'email'))
+        ->toBeTrue();
+});
+
+test('hasAny returns true with values', function () {
+    $bag = BagWithOptionals::from(['name' => 'Davey Shafik', 'age' => 40, 'email' => 'davey@php.net']);
+
+    expect($bag->hasAny('age', 'email'))
+        ->toBeTrue();
+});
+
+test('hasAll returns false with optionals', function () {
+    $bag = BagWithOptionals::from(['name' => 'Davey Shafik']);
+
+    expect($bag->hasAll('age', 'email'))
+        ->toBeFalse();
+});
+
+test('hasAll returns false with null', function () {
+    $bag = BagWithOptionals::from(['name' => 'Davey Shafik', 'email' => null]);
+
+    expect($bag->hasAll('age', 'email'))
+        ->toBeFalse();
+});
+
+test('hasAll returns true with values', function () {
+    $bag = BagWithOptionals::from(['name' => 'Davey Shafik', 'age' => 40, 'email' => 'davey@php.net']);
+
+    expect($bag->hasALl('age', 'email'))
+        ->toBeTrue();
+});

--- a/tests/Feature/Concerns/WithOptionalsTest.php
+++ b/tests/Feature/Concerns/WithOptionalsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Bag\Concerns\WithOptionals;
+use Tests\Fixtures\Values\BagWithOptionals;
+
+covers(WithOptionals::class);
+
+test('has returns false with optional', function () {
+    $bag = BagWithOptionals::from(['name' => 'Davey Shafik']);
+
+    expect($bag->has('age'))
+        ->toBeFalse()
+    ->and($bag->has('email'))
+        ->toBeFalse();
+});
+
+test('has returns true with null', function () {
+    $bag = BagWithOptionals::from(['name' => 'Davey Shafik', 'email' => null]);
+
+    expect($bag->has('age'))
+        ->toBeFalse()
+    ->and($bag->has('email'))
+        ->toBeTrue();
+});
+
+test('has returns true with value', function () {
+    $bag = BagWithOptionals::from(['name' => 'Davey Shafik', 'age' => 40, 'email' => 'davey@php.net']);
+
+    expect($bag->has('age'))
+        ->toBeTrue()
+     ->and($bag->has('email'))
+         ->toBeTrue();
+});

--- a/tests/Fixtures/Values/BagWithMappingAndOptional.php
+++ b/tests/Fixtures/Values/BagWithMappingAndOptional.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Values;
+
+use Bag\Attributes\MapInputName;
+use Bag\Bag;
+use Bag\Mappers\SnakeCase;
+use Bag\Values\Optional;
+
+#[MapInputName(SnakeCase::class)]
+readonly class BagWithMappingAndOptional extends Bag
+{
+    public function __construct(
+        public string $name,
+        public Optional|int $currentAge,
+    ) {
+    }
+}

--- a/tests/Fixtures/Values/BagWithOptionals.php
+++ b/tests/Fixtures/Values/BagWithOptionals.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Values;
+
+use Bag\Bag;
+use Bag\Values\Optional;
+
+readonly class BagWithOptionals extends Bag
+{
+    public function __construct(
+        public string $name,
+        public Optional|int $age,
+        public Optional|string|null $email,
+    ) {
+    }
+}

--- a/tests/Fixtures/Values/BagWithOptionalsAndValidation.php
+++ b/tests/Fixtures/Values/BagWithOptionalsAndValidation.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Values;
+
+use Bag\Bag;
+use Bag\Values\Optional;
+
+readonly class BagWithOptionalsAndValidation extends Bag
+{
+    public function __construct(
+        public string $name,
+        public Optional|int $age,
+        public Optional|string|null $email,
+    ) {
+    }
+
+    public static function rules(): array
+    {
+        return [
+            'name' => ['required', 'string'],
+            'age' => [new Optional('integer')],
+            'email' => [new Optional('string')],
+        ];
+    }
+}

--- a/tests/Unit/Internal/ValidatorTest.php
+++ b/tests/Unit/Internal/ValidatorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Bag\Internal\Validator;
+use Illuminate\Validation\ValidationException;
+
+covers(Validator::class);
+
+test('it does not throw when valid', function () {
+    Validator::validate(['name' => 'Davey Shafik'], collect(['name' => ['string']]));
+})->throwsNoExceptions();
+
+test('it does throw when invalid', function () {
+    Validator::validate(['name' => 'Davey Shafik'], collect(['name' => ['int']]));
+})->throws(ValidationException::class, 'The name field must be an integer.');
+
+test('it does not throw when valid without facade root', function () {
+    \Illuminate\Support\Facades\Validator::setFacadeApplication(null);
+
+    Validator::validate(['name' => 'Davey Shafik'], collect(['name' => ['string']]));
+})->throwsNoExceptions();
+
+test('it throws when invalid without facade root', function () {
+    \Illuminate\Support\Facades\Validator::setFacadeApplication(null);
+
+    Validator::validate(['name' => 'Davey Shafik'], collect(['name' => ['int']]));
+})->throws(ValidationException::class, 'The name field must be an integer.');

--- a/tests/Unit/Pipelines/Pipes/FillNullsTest.php
+++ b/tests/Unit/Pipelines/Pipes/FillNullsTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Bag\Pipelines\Pipes\FillNulls;
+use Bag\Pipelines\Pipes\MapInput;
 use Bag\Pipelines\Pipes\ProcessParameters;
 use Bag\Pipelines\Values\BagInput;
 use Tests\Fixtures\Values\NullablePropertiesBag;
@@ -13,19 +14,21 @@ covers(FillNulls::class);
 test('fill nulls', function () {
     $input = new BagInput(NullablePropertiesBag::class, collect());
     $input = (new ProcessParameters())($input);
+    $input = (new MapInput())($input);
 
     $pipe = new FillNulls();
     $input = $pipe($input);
 
-    expect($input->input->toArray())->toBe(['name' => null, 'age' => null, 'email' => null, 'bag' => null]);
+    expect($input->values->toArray())->toBe(['name' => null, 'age' => null, 'email' => null, 'bag' => null]);
 });
 
 test('do not fill defaults', function () {
     $input = new BagInput(OptionalPropertiesWithDefaultsBag::class, collect());
     $input = (new ProcessParameters())($input);
+    $input = (new MapInput())($input);
 
     $pipe = new FillNulls();
     $input = $pipe($input);
 
-    expect($input->input->toArray())->toBeEmpty();
+    expect($input->values->toArray())->toBeEmpty();
 });

--- a/tests/Unit/Pipelines/Pipes/FillOptionalsTest.php
+++ b/tests/Unit/Pipelines/Pipes/FillOptionalsTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use Bag\Pipelines\Pipes\FillOptionals;
+use Bag\Pipelines\Pipes\MapInput;
+use Bag\Pipelines\Pipes\ProcessParameters;
+use Bag\Pipelines\Values\BagInput;
+use Bag\Values\Optional;
+use Tests\Fixtures\Values\BagWithOptionals;
+
+covers(FillOptionals::class);
+
+test('it sets missing optionals to Optional', function () {
+    $input = new BagInput(BagWithOptionals::class, collect(['name' => 'Davey Shafik']));
+    $input = (new ProcessParameters())($input);
+    $input = (new MapInput())($input);
+
+    $pipe = new FillOptionals();
+    $input = $pipe($input);
+
+    expect($input->values->get('name'))
+        ->toBe('Davey Shafik')
+        ->and($input->values->get('age'))
+        ->toBeInstanceOf(Optional::class)
+        ->and($input->values->get('email'))
+        ->toBeInstanceOf(Optional::class);
+});
+
+test('it sets nullable optionals explicitly to null', function () {
+    $input = new BagInput(BagWithOptionals::class, collect(['name' => 'Davey Shafik', 'email' => null]));
+    $input = (new ProcessParameters())($input);
+    $input = (new MapInput())($input);
+
+    $pipe = new FillOptionals();
+    $input = $pipe($input);
+
+    expect($input->values->get('name'))
+        ->toBe('Davey Shafik')
+    ->and($input->values->get('age'))
+        ->toBeInstanceOf(Optional::class)
+    ->and($input->values->get('email'))
+        ->toBeNull();
+});
+
+test('it sets optionals to specified values', function () {
+    $input = new BagInput(BagWithOptionals::class, collect([
+        'name' => 'Davey Shafik',
+        'age' => 40,
+        'email' => 'davey@php.net'
+    ]));
+    $input = (new ProcessParameters())($input);
+    $input = (new MapInput())($input);
+
+    $pipe = new FillOptionals();
+    $input = $pipe($input);
+
+    expect($input->values->get('name'))
+        ->toBe('Davey Shafik')
+    ->and($input->values->get('age'))
+        ->toBe(40)
+    ->and($input->values->get('email'))
+        ->toBe('davey@php.net');
+});
+
+
+test('it sets non-nullable optionals to Optional when null', function () {
+    $input = new BagInput(BagWithOptionals::class, collect([
+        'name' => 'Davey Shafik',
+        'age' => null,
+    ]));
+    $input = (new ProcessParameters())($input);
+    $input = (new MapInput())($input);
+
+    $pipe = new FillOptionals();
+    $input = $pipe($input);
+
+    expect($input->values->get('name'))
+        ->toBe('Davey Shafik')
+    ->and($input->values->get('age'))
+        ->toBeInstanceOf(Optional::class)
+    ->and($input->values->get('email'))
+        ->toBeInstanceOf(Optional::class);
+});

--- a/tests/Unit/Pipelines/Pipes/HideOptionalValuesTest.php
+++ b/tests/Unit/Pipelines/Pipes/HideOptionalValuesTest.php
@@ -9,6 +9,8 @@ use Bag\Pipelines\Pipes\ProcessProperties;
 use Bag\Pipelines\Values\BagOutput;
 use Tests\Fixtures\Values\BagWithOptionals;
 
+covers(HideOptionalValues::class);
+
 test('it hides optionals when Optional', function () {
     $bag = BagWithOptionals::from(['name' => 'Davey Shafik']);
 

--- a/tests/Unit/Pipelines/Pipes/HideOptionalValuesTest.php
+++ b/tests/Unit/Pipelines/Pipes/HideOptionalValuesTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use Bag\Enums\OutputType;
+use Bag\Pipelines\Pipes\HideOptionalValues;
+use Bag\Pipelines\Pipes\ProcessParameters;
+use Bag\Pipelines\Pipes\ProcessProperties;
+use Bag\Pipelines\Values\BagOutput;
+use Tests\Fixtures\Values\BagWithOptionals;
+
+test('it hides optionals when Optional', function () {
+    $bag = BagWithOptionals::from(['name' => 'Davey Shafik']);
+
+    $output = new BagOutput($bag, OutputType::ARRAY);
+    $output = (new ProcessProperties())($output);
+    $output = (new ProcessParameters())($output);
+    $output->values = $bag->getRaw();
+
+    $pipe = new HideOptionalValues();
+    $output = $pipe($output);
+
+    expect($output->values->toArray())->toBe([
+        'name' => 'Davey Shafik',
+    ]);
+});
+
+test('it does not hide optionals when not Optional', function () {
+    $bag = BagWithOptionals::from(['name' => 'Davey Shafik', 'age' => 40, 'email' => 'davey@php.net']);
+
+    $output = new BagOutput($bag, OutputType::ARRAY);
+    $output = (new ProcessProperties())($output);
+    $output = (new ProcessParameters())($output);
+    $output->values = $bag->getRaw();
+
+    $pipe = new HideOptionalValues();
+    $output = $pipe($output);
+
+    expect($output->values->toArray())->toBe([
+        'name' => 'Davey Shafik',
+        'age' => 40,
+        'email' => 'davey@php.net',
+    ]);
+});
+
+test('it does not hide optionals when null', function () {
+    $bag = BagWithOptionals::from(['name' => 'Davey Shafik', 'age' => 40, 'email' => null]);
+
+    $output = new BagOutput($bag, OutputType::ARRAY);
+    $output = (new ProcessProperties())($output);
+    $output = (new ProcessParameters())($output);
+    $output->values = $bag->getRaw();
+
+    $pipe = new HideOptionalValues();
+    $output = $pipe($output);
+
+    expect($output->values->toArray())->toBe([
+        'name' => 'Davey Shafik',
+        'age' => 40,
+        'email' => null,
+    ]);
+});

--- a/tests/Unit/Property/ValueTest.php
+++ b/tests/Unit/Property/ValueTest.php
@@ -5,6 +5,7 @@ use Bag\Property\CastInput;
 use Bag\Property\CastOutput;
 use Bag\Property\ValidatorCollection;
 use Bag\Property\Value;
+use Tests\Fixtures\Values\BagWithOptionals;
 use Tests\Fixtures\Values\ValidateMappedNameClassBag;
 
 covers(Value::class);
@@ -55,4 +56,18 @@ test('it creates value from parameter', function () {
         ->and($value->validators->all())->toBe(['string', 'required'])
         ->and($value->variadic)->toBeFalse();
 
+});
+
+test('it handles optionals', function () {
+    $class = new \ReflectionClass(BagWithOptionals::class);
+    $property = $class->getConstructor()->getParameters()[2];
+
+    $value = Value::create($class, $property);
+
+    expect($value->optional)
+        ->toBeTrue()
+    ->and($value->required)
+        ->toBeFalse()
+    ->and($value->allowsNull)
+        ->toBeTrue();
 });

--- a/tests/Unit/Validation/Rules/OptionalOrTest.php
+++ b/tests/Unit/Validation/Rules/OptionalOrTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use Bag\Validation\Rules\OptionalOr;
+use Bag\Values\Optional;
+use Illuminate\Support\Facades\Validator;
+
+covers(OptionalOr::class);
+
+test('it validates optionals with types', function () {
+    $validator = Validator::make([
+        'name' => 'Davey Shafik',
+        'age' => new Optional(),
+        'email' => new Optional(),
+    ], [
+        'name' => ['required', 'string'],
+        'age' => [new OptionalOr('int')],
+        'email' => [new OptionalOr('string')],
+    ]);
+
+    expect($validator->passes())->toBeTrue();
+});
+
+test('it validates optionals without types', function () {
+    $validator = Validator::make([
+        'name' => 'Davey Shafik',
+        'age' => new Optional(),
+        'email' => new Optional(),
+    ], [
+        'name' => ['required', 'string'],
+        'age' => [new OptionalOr()],
+        'email' => new OptionalOr(),
+    ]);
+
+    expect($validator->passes())->toBeTrue();
+});
+
+test('it validates optionals with validation', function () {
+    $validator = Validator::make([
+        'name' => 'Davey Shafik',
+        'age' => new Optional(),
+        'email' => new Optional(),
+    ], [
+        'name' => ['required', 'string'],
+        'age' => [new OptionalOr('int')],
+        'email' => [new OptionalOr('email')],
+    ]);
+
+    expect($validator->passes())->toBeTrue();
+});
+
+test('it validates optionals with nulls', function () {
+    $validator = Validator::make([
+        'name' => 'Davey Shafik',
+        'age' => 40,
+        'email' => 'davey@php.net',
+    ], [
+        'name' => ['required', 'string'],
+        'age' => [new OptionalOr('int')],
+        'email' => [new OptionalOr(['nullable', 'email'])],
+    ]);
+
+    expect($validator->passes())->toBeTrue();
+});
+
+test('it validates classnames', function () {
+    $validator = Validator::make([
+        'date' => new \DateTimeImmutable(),
+    ], [
+        'date' => [new OptionalOr(\DateTimeImmutable::class)],
+    ]);
+
+    expect($validator->passes())->toBeTrue();
+});
+
+test('it fails to validate invalid classnames', function () {
+    $validator = Validator::make([
+        'date' => new \DateTime(),
+    ], [
+        'date' => [new OptionalOr(\DateTimeImmutable::class)],
+    ]);
+
+    expect($validator->passes())->toBeFalse();
+});
+
+test('it fails validation for values', function () {
+    $validator = Validator::make([
+        'name' => 'Davey Shafik',
+        'age' => 40,
+        'email' => null,
+    ], [
+        'name' => ['required', 'string'],
+        'age' => [new OptionalOr('int')],
+        'email' => [new OptionalOr(['required', 'email'])],
+    ]);
+
+    expect($validator->passes())->toBeFalse();
+});


### PR DESCRIPTION
fixes: #87
implements: #88

---------

# Optionals

Bag supports optional parameters using the `Optional` class. `Optional` parameters are parameters 
that can be omitted when creating a Bag object, and will automatically be excluded from array and JSON 
representations.

[!NOTE]
> Optional parameters are _different_ from nullable parameters, nulls are still included in the output, 
> and can be combined with `Optional`. Optional parameters **will not** be filled with nulls when omitted. 

[!WARN]
> You _must_ specify at least one other type. Optionals cannot be combined with `mixed`.

To make a property optional, use a union type that includes `Optional`:

```php
use Bag\Bag;

class MyValue extends Bag
{
    public function __construct(
        public string $name,
        public Optional|int $age,
        public Optional|string|null $email = null,
    ) {}
}
```

In the above example, the `age` property is optional, and can be omitted when creating a `MyValue` object:

```php
$value = new MyValue(name: 'Davey Shafik', email: null);

$value->toArray(); // ['name' => 'Davey Shafik', 'email' => null]
$value->toJson(); // {"name": "Davey Shafik", "email": null}
```

In the above example, the `age` property is omitted, and the `email` property is explicitly set to `null`. Omitting the `email` property would result in an `Optional` being used.

## Value Presence

Because optional properties are set to the `Optional` class, a simple `isset()` check will not work. Instead, you must use the `->has()` method instead:

```php
$value = new MyValue(name: 'Davey Shafik', email: null);

$value->has('name'); // true
$value->has('age'); // false
$value->has('email'); // true
```

## Validation

Because Optional properties have a value (an `Optional` object), validation may not work like expected. Bag provides
a custom wrapper rule `\Bag\Validation\Rules\Optional` that can be used to validate optional properties correctly.

The `Optional` rule will pass validation if the property is set to Optional, but will run the validation rules on the value if it is not:

```php
use Bag\Bag;
use Bag\Validation\Rules\OptionalOr;

class MyValue extends Bag
{
    public function __construct(
        public string $name,
        public Optional|int $age,
        public Optional|string|null $email = null,
    ) {}

    public function rules(): array
    {
        return [
            'age' => [new OptionalOr(['required', 'integer'])],
            'email' => [new OptionalOr(['nullable', 'email'])],
        ];
    }
}

// All of the following are valid

// both age and email are optional
$value = new MyValue(name: 'Davey Shafik'); 
// age is an int, email is optional
$value = new MyValue(name: 'Davey Shafik', age: 40); 
// age is optional, email is nullable
$value = new MyValue(name: 'Davey Shafik', email: null) 
// age is integer, email is an email
$value = new MyValue(name: 'Davey Shafik', age: 40, email: 'davey@php.net') 

// While these are invalid:

// age is not an int, email is optional
$value = new MyValue(name: 'Davey Shafik', age: '40'); 

// age is required, email is optional
$value = new MyValue(name: 'Davey Shafik', age: null); 

// email is not an email, age is optional
$value = new MyValue(name: 'Davey Shafik', email: 'foo'); 
```

The `OptionalOr` class accepts an array of rules, a single string rule, or a class name that the value should be an `instanceof`.


