### PR TITLE
fix: use __invoke to inject request classes on invokable controller

### DIFF
--- a/src/Bag/BagServiceProvider.php
+++ b/src/Bag/BagServiceProvider.php
@@ -45,7 +45,12 @@ class BagServiceProvider extends ServiceProvider
                             $action = new ReflectionClosure($closure);
                         } else {
                             /** @var object|string $controller */
-                            $action = new ReflectionMethod($controller, $route->getActionMethod());
+                            $method = $route->getActionMethod();
+                            $name = is_string($controller) ? $controller : get_class($controller);
+                            if ($method === $name) {
+                                $method = '__invoke';
+                            }
+                            $action = new ReflectionMethod($controller, $method);
                         }
 
                         if (Reflection::getParameters($action)->filter(function ($parameter) use ($class) {

--- a/tests/Feature/BagServiceProviderTest.php
+++ b/tests/Feature/BagServiceProviderTest.php
@@ -145,3 +145,26 @@ test('it resolves and strips extra paramaters using class method route', functio
         ->and(\Test2::$resolved->toArray())
         ->toBe(['name' => 'Davey Shafik', 'age' => 40, 'email' => 'davey@php.net']);
 });
+
+test('it uses the __invoke method for invokable classes', function () {
+    class TestInvokable
+    {
+        public static TestBag $resolved;
+
+        public function __invoke(TestBag $bag)
+        {
+            static::$resolved = $bag;
+
+            return $bag;
+        }
+    }
+
+    Route::post('/testinvoke', \TestInvokable::class);
+
+    $this->post('/testinvoke', ['name' => 'Davey Shafik', 'age' => 40, 'email' => 'davey@php.net']);
+
+    expect(\TestInvokable::$resolved)
+        ->toBeInstanceOf(TestBag::class)
+        ->and(\TestInvokable::$resolved->toArray())
+        ->toBe(['name' => 'Davey Shafik', 'age' => 40, 'email' => 'davey@php.net']);
+});


### PR DESCRIPTION
When using a single-action controller with an `__invoke` method,  `$route->getActionMethod()` will return the name of the controller instead of any usable method, so we end up getting baffling errors about methods like `App\Http\Controllers\My\Controller::App\Http\Controllers\My\Controller()` not existing.  Arguably this is a bug in Laravel, but we have to work around it, so this detects if the method is identical to the controller, and switches it to `__invoke` if so.

