### PR TITLE
Expose arguments of MissingPropertiesException

### DIFF
--- a/src/Bag/Exceptions/MissingPropertiesException.php
+++ b/src/Bag/Exceptions/MissingPropertiesException.php
@@ -9,7 +9,7 @@ use Exception;
 
 class MissingPropertiesException extends Exception
 {
-    public function __construct(string $bagClassname, ValueCollection $missingParameters)
+    public function __construct(public string $bagClassname, public ValueCollection $missingParameters)
     {
         parent::__construct(sprintf(
             'Missing required properties for Bag %s: %s',


### PR DESCRIPTION
Currently when receiving a MissingPropertiesException, it's difficult to show descriptive validation messages to a user when using Bags as request validation.

This commit exposes the 2 inputs to `MissingPropertiesException` so one can read _which_ parameters were missing.