### PR TITLE
feat: Support for Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,75 +1,75 @@
 {
-    "name": "beacon-hq/bag",
-    "description": "A comprehensive immutable value objects implementation",
-    "type": "library",
-    "replace": {
-        "dshafik/bag": "self.version"
-    },
-    "require": {
-        "php": "^8.2|^8.3|^8.4",
-        "brick/money": "^0.8.1 || ^0.9.0 || ^0.10.0",
-        "illuminate/collections": "^10|^11|^12",
-        "illuminate/database": "^10|^11|^12",
-        "illuminate/support": "^10|^11|^12",
-        "illuminate/validation": "^10|^11|^12",
-        "nette/php-generator": "^4.1",
-        "prinsfrank/standards": "^3.8",
-        "ramsey/uuid": "^4.7",
-        "league/pipeline": "^1.0"
-    },
-    "require-dev": {
-        "captainhook/captainhook-phar": "^5.23",
-        "captainhook/hook-installer": "^1.0",
-        "larastan/larastan": "^2.0|^3.0",
-        "laravel/pint": "^1.15",
-        "laravel/prompts": "^0.1.25 || ^0.2.0 || ^0.3.0",
-        "orchestra/pest-plugin-testbench": "^2.0|^3.0",
-        "pestphp/pest": "^2.0|^3.0",
-        "pestphp/pest-plugin-faker": "^2.0|^3.0",
-        "pestphp/pest-plugin-type-coverage": "^2.0|^3.0",
-        "ramsey/conventional-commits": "^1.5.1",
-        "roave/security-advisories": "dev-latest",
-        "symfony/var-dumper": "*"
-    },
-    "suggest": {
-        "barryvdh/laravel-debugbar": "Integrates with Laravel Debugbar",
-        "spatie/typescript-transformer": "Easily transform Bag Value objects into TypeScript types",
-        "spatie/laravel-typescript-transformer": "Easily transform Bag Value objects into TypeScript types within Laravel applications"
-    },
-    "license": "MIT",
-    "autoload": {
-        "psr-4": {
-            "Bag\\": "src/Bag"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Tests\\": "tests"
-        }
-    },
-    "scripts": {
-        "test": "pest",
-        "style": "pint"
-    },
-    "extra" : {
-        "laravel" : {
-            "providers" : [
-                "\\Bag\\BagServiceProvider"
-            ]
-        }
-    },
-    "authors": [
-        {
-            "name": "Davey Shafik",
-            "email": "davey@php.net"
-        }
-    ],
-    "config": {
-        "allow-plugins": {
-            "captainhook/captainhook-phar": true,
-            "captainhook/hook-installer": true,
-            "infection/extension-installer": true,
-            "pestphp/pest-plugin": true
-        }
+  "name": "beacon-hq/bag",
+  "description": "A comprehensive immutable value objects implementation",
+  "type": "library",
+  "replace": {
+    "dshafik/bag": "self.version"
+  },
+  "require": {
+    "php": "^8.2|^8.3|^8.4|^8.5",
+    "brick/money": "^0.8.1 || ^0.9.0 || ^0.10.0",
+    "illuminate/collections": "^10|^11|^12|^13",
+    "illuminate/database": "^10|^11|^12|^13",
+    "illuminate/support": "^10|^11|^12|^13",
+    "illuminate/validation": "^10|^11|^12|^13",
+    "nette/php-generator": "^4.1",
+    "prinsfrank/standards": "^3.8",
+    "ramsey/uuid": "^4.7",
+    "league/pipeline": "^1.0"
+  },
+  "require-dev": {
+    "captainhook/captainhook-phar": "^5.23",
+    "captainhook/hook-installer": "^1.0",
+    "larastan/larastan": "^2.0|^3.0",
+    "laravel/pint": "^1.15",
+    "laravel/prompts": "^0.1.25 || ^0.2.0 || ^0.3.0",
+    "orchestra/pest-plugin-testbench": "^2.0|^3.0|^4.0",
+    "pestphp/pest": "^2.0|^3.0|^4.0",
+    "pestphp/pest-plugin-faker": "^2.0|^3.0|^4.0",
+    "pestphp/pest-plugin-type-coverage": "^2.0|^3.0|^4.0",
+    "ramsey/conventional-commits": "^1.5.1",
+    "roave/security-advisories": "dev-latest",
+    "symfony/var-dumper": "*"
+  },
+  "suggest": {
+    "barryvdh/laravel-debugbar": "Integrates with Laravel Debugbar",
+    "spatie/typescript-transformer": "Easily transform Bag Value objects into TypeScript types",
+    "spatie/laravel-typescript-transformer": "Easily transform Bag Value objects into TypeScript types within Laravel applications"
+  },
+  "license": "MIT",
+  "autoload": {
+    "psr-4": {
+      "Bag\\": "src/Bag"
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Tests\\": "tests"
+    }
+  },
+  "scripts": {
+    "test": "pest",
+    "style": "pint"
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "\\Bag\\BagServiceProvider"
+      ]
+    }
+  },
+  "authors": [
+    {
+      "name": "Davey Shafik",
+      "email": "davey@php.net"
+    }
+  ],
+  "config": {
+    "allow-plugins": {
+      "captainhook/captainhook-phar": true,
+      "captainhook/hook-installer": true,
+      "infection/extension-installer": true,
+      "pestphp/pest-plugin": true
+    }
+  }
 }

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-beforeEach()->coversNothing();
+beforeEach()->covers();
 
 arch('it does not call dd()')->expect('dd')->not->toBeUsed();
 arch('it does not call ddd()')->expect('ddd')->not->toBeUsed();
@@ -10,7 +10,7 @@ arch('it does not call dump()')->expect('dump')->not->toBeUsed();
 arch('it does not call xdebug_break()')->expect('xdebug_break')->not->toBeUsed();
 
 arch('it meets PHP preset')
-    ->skip(fn () => !version_compare(Pest\version(), '3.0.0', '>='), 'Requires Pest 3+')
+    ->skip(fn () => ! version_compare(Pest\version(), '3.0.0', '>='), 'Requires Pest 3+')
     ->preset()
     ->php()
     ->ignoring(['var_export', 'debug_backtrace']);


### PR DESCRIPTION
Description
--
This PR adds support for Laravel 13.

## Changes
1. Added support for PHP 8.5, by updating the `php` requirement to include `|^8.5`
2. Added support for v13 illuminate packages: `|^13`
3. Added support for Pest PHP `4.0` (same with all pest plugins)
4. Switched the `->coversNothing()` in `tests/ArchTest.php` to instead use `->covers()`

## Related Issue
Fix for issue #126 